### PR TITLE
Corrected an IPA sign

### DIFF
--- a/3/2/index.html
+++ b/3/2/index.html
@@ -129,7 +129,7 @@
 </tr>
 <tr>
 <td>n</td>
-<td class="c3">[n], [n̩], [ŋ̍], [ŋ̩]</td>
+<td class="c3">[n], [n̩], [ŋ], [ŋ̩]</td>
 <td>[n], [n=], [N], [N=]</td>
 <td>a voiced dental or velar nasal (may be syllabic)</td>
 </tr>


### PR DESCRIPTION
[ŋ̍] was replaced with [ŋ] on the table in the section 3.2.
The IPA signs for the letter n were displayed as
[n], [n̩], [ŋ̍], [ŋ̩]
but the third one should be a non-syllabic [ŋ].
