### PR TITLE
li ci bi'e pi'u vo su'i mu du li paze -> li ci bi'e <pi'i> vo su'i mu du...

### DIFF
--- a/chapters/08.xml
+++ b/chapters/08.xml
@@ -1476,7 +1476,7 @@
         <anchor xml:id="c8e10d3"/>
       </title>
       <interlinear-gloss>
-        <jbo>le prenu poi ke'a goi ko'a zo'u ko'a zvati le kumfa poi ke'a goi ko'e zo'u ko'a zbasu ke'a cu masno</jbo>
+        <jbo>le prenu poi ke'a goi ko'a zo'u ko'a zvati le kumfa poi ke'a goi ko'e zo'u ko'a zbasu ko'e cu masno</jbo>
         <gloss>The man who (IT = it1 : it1 is-in the room which (IT = it2 : it1 built it2) is-slow.</gloss>
       </interlinear-gloss>
     </example>

--- a/chapters/20.xml
+++ b/chapters/20.xml
@@ -88,7 +88,7 @@
     
     <para>Prefixed to a mathematical operator to mark it as higher priority than other mathematical operators, binding its operands more closely.</para>
     <programlisting xml:space="preserve">
-      li ci bi'e pi'u vo su'i mu du li paze
+      li ci bi'e pi'i vo su'i mu du li paze
       The-number 3 [priority] times 4 plus 5 equals the-number 17.
       3 × 4 + 5 = 17
     </programlisting>

--- a/chapters/20.xml
+++ b/chapters/20.xml
@@ -1342,7 +1342,7 @@
     
     <para>Separates a logical prenex from a bridi or group of sentences to which it applies. Also separates a topic from a comment in topic/comment sentences.</para>
     <programlisting xml:space="preserve">
-      su'o da poi remna ro da poi finpe zo'u da prami de
+      su'o da poi remna ro de poi finpe zo'u da prami de
       For-at-least-one X which is-a-man, for-all Ys which are-fish : X loves Y
       There is a man who loves all fish.
     </programlisting>


### PR DESCRIPTION
I think that "pi'i" is correct not "pi'u".
