### PR TITLE
Fix getopts syntax in builds/script

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -21,7 +21,7 @@ $(grep '^[a-z][a-z_]*:' build/Makefile | sed 's/:.*//' | sed 's/^/    /')
 optlist=""
 target="all"
 
-while getopts "sthT" opt
+while getopts "sthT:" opt
 do
   case "$opt" in
     s)    optlist="$optlist -s";;


### PR DESCRIPTION
According to the [Bash manual](http://www.gnu.org/software/bash/manual/html_node/Bourne-Shell-Builtins.html#index-getopts-116),

```
if a character is followed by a colon, the option is expected to have an argument
```

Without this fix, the script confuses the target for a chapter. Tested on Mac OS X 10.7 (GNU bash, version 3.2.48(1)-release (x86_64-apple-darwin11)) and Ubuntu 12 (GNU bash, version 4.2.24(1)-release (x86_64-pc-linux-gnu).

```
$ scripts/build -T epub


Since you specified chapters, you need to specify -s or -t.  -t is faster.




Usage: scripts/build [-s] [-t] [-T target] [chapters]

-s: Replaces external xrefs in each chapter, so each chapter works standalone.

-t: Does what -s does, but also prevents most glossary processing so the glossary building goes much faster.

-T target: Specifies the make target.  Most of them are obvious.  The _web targets copy stuff into your ~/public_html/ web space.  Complete list:

    all
    clean
    realclean
    xhtml_web
    xhtml
    xhtml_sections_web
    xhtml_sections
    xhtml_nochunks_web
    xhtml_nochunks
    epub
    epub_web
    mobi
    mobi_web
    pdf
    pdf_web

[chapters]: defaults to all chapters; if you specify less than all chapters, you must use -s or -t
```
