### PR TITLE
8.10: Use assigned ko'e as indicated rather than ke'a

### DIFF
--- a/chapters/08.xml
+++ b/chapters/08.xml
@@ -1476,7 +1476,7 @@
         <anchor xml:id="c8e10d3"/>
       </title>
       <interlinear-gloss>
-        <jbo>le prenu poi ke'a goi ko'a zo'u ko'a zvati le kumfa poi ke'a goi ko'e zo'u ko'a zbasu ke'a cu masno</jbo>
+        <jbo>le prenu poi ke'a goi ko'a zo'u ko'a zvati le kumfa poi ke'a goi ko'e zo'u ko'a zbasu ko'e cu masno</jbo>
         <gloss>The man who (IT = it1 : it1 is-in the room which (IT = it2 : it1 built it2) is-slow.</gloss>
       </interlinear-gloss>
     </example>

--- a/chapters/09.xml
+++ b/chapters/09.xml
@@ -2591,13 +2591,13 @@
         <cmavo><valsi>ra'a</valsi></cmavo>
         <gismu><valsi>srana</valsi></gismu>
         <modal-place>pertained to by</modal-place>
-        <modal-place>concerning</modal-place>
+        <modal-place se="se">concerning</modal-place>
       </cmavo-entry>
       <cmavo-entry>
         <cmavo><valsi>ra'i</valsi></cmavo>
         <gismu><valsi>krasi</valsi></gismu>
         <modal-place>from source</modal-place>
-        <modal-place>as an origin of</modal-place>
+        <modal-place se="se">as an origin of</modal-place>
       </cmavo-entry>
       <cmavo-entry>
         <cmavo>rai</cmavo>

--- a/chapters/10.xml
+++ b/chapters/10.xml
@@ -1281,7 +1281,9 @@
     <xref linkend="section-vagueness"/>, the simple PU cmavo make no assumptions about whether the scope of a past, present, or future event extends into one of the other tenses as well. 
 
     <xref linkend="example-random-id-qdwz"/> through 
-    <xref linkend="example-random-id-qdxB"/> illustrate that these ZAhO cmavo do make such assumptions possible: the event in 10.1 has not yet begun, definitively; likewise, the event in 10.3 is definitely over.</para>
+    <xref linkend="example-random-id-qdxB"/> illustrate that these ZAhO cmavo do make such assumptions possible: the event in 
+    <xref linkend="example-random-id-qdwz"/> has not yet begun, definitively; likewise, the event in 
+    <xref linkend="example-random-id-qdxB"/> is definitely over.</para>
   <para> <indexterm type="general-imported"><primary>ba'o</primary><secondary>as futureward of event</secondary></indexterm>  <indexterm type="general-imported"><primary>pu'o</primary><secondary>as pastward of event</secondary></indexterm>  <indexterm type="general-imported"><primary>ba'o</primary><secondary>explanation of derivation</secondary></indexterm>  <indexterm type="general-imported"><primary>pu'o</primary><secondary>explanation of derivation</secondary></indexterm> Note that in 
     <xref linkend="example-random-id-qdwz"/> and 
     <xref linkend="example-random-id-qdxB"/>, 
@@ -2339,7 +2341,8 @@
     <para> <indexterm type="general-imported"><primary>tensed logical connectives</primary></indexterm>  <indexterm type="general-imported"><primary>logical connectives</primary><secondary>tensed</secondary></indexterm> The Lojban tense system interacts with the Lojban logical connective system. That system is a separate topic, explained in 
     
     <xref linkend="chapter-connectives"/> and touched on only in summary here. By the rules of the logical connective system, 
-    <xref linkend="example-random-id-qehB"/> through 17.3 are equivalent in meaning:</para>
+    <xref linkend="example-random-id-qehB"/> through 
+    <xref linkend="example-random-id-qEIm"/> are equivalent in meaning:</para>
     <example xml:id="example-random-id-qehB" role="interlinear-gloss-example">
       <title>
         <anchor xml:id="c10e17d1"/>
@@ -2406,7 +2409,8 @@
       </interlinear-gloss>
     </example>
     <para> <indexterm type="general-imported"><primary>tensed logically connected sumti</primary></indexterm>  <indexterm type="general-imported"><primary>tensed logically connected bridi-tails</primary></indexterm>  <indexterm type="general-imported"><primary>tensed logically connected sentences</primary></indexterm> 
-    <xref linkend="example-random-id-qEiY"/> through 17.6 are equivalent in meaning. They are also analogous to 
+    <xref linkend="example-random-id-qEiY"/> through 
+    <xref linkend="example-random-id-qEKa"/> are equivalent in meaning. They are also analogous to 
     <xref linkend="example-random-id-qehB"/> through 
     <xref linkend="example-random-id-qEIm"/> respectively. The 
     <valsi>bo</valsi> is required for the same reason as in 

--- a/chapters/10.xml
+++ b/chapters/10.xml
@@ -2330,7 +2330,7 @@
       </varlistentry>
       <varlistentry>
         <term>forethought coordinate:</term>
-        <listitem><grammar-template>TENSE+gi X gi Y</grammar-template></listitem>
+        <listitem><grammar-template>TENSE+gi Y gi X</grammar-template></listitem>
       </varlistentry>
     </variablelist>
   </section>

--- a/chapters/12.xml
+++ b/chapters/12.xml
@@ -1080,7 +1080,7 @@ On the other hand, the lujvo
       <para><definition><content>nu1 is the event of k1's coming/going to k2 from k3 via route k4 by means k5.</content></definition></para>
     </example>
     <para>Here the first place of 
-    <valsi>nunklama</valsi> is the first and only place of 
+    <valsi>nunkla</valsi> is the first and only place of 
     <valsi>nu</valsi>, and the other five places have been pushed down by one to occupy the second through the sixth places. Full information on 
     <valsi>nu</valsi>, as well as the other abstractors mentioned in this section, is given in 
     <xref linkend="chapter-abstractions"/>.</para>

--- a/chapters/13.xml
+++ b/chapters/13.xml
@@ -1227,7 +1227,7 @@
     <para> <indexterm type="general-imported"><primary>imperatives</primary><secondary>attitude</secondary></indexterm> Note that imperatives in Lojban need not be imperious! Corresponding examples with 
     
     <valsi>ga'icu'i</valsi> and 
-    <valsi>ga'inai</valsi>:</para>
+    <valsi>ga'i</valsi>:</para>
     
     <example xml:id="example-random-id-qfWn" role="interlinear-gloss-example">
       <title>


### PR DESCRIPTION
An example in 8.10 seems inconsistent with the gloss and, while technically correct, kind of silly as written.

Note that I'm new to lojban, so I might have misunderstood something here, but I think this was what was intended.
