### PR TITLE
Fix issues #26 #32 #52 #91

### DIFF
--- a/chapters/04.xml
+++ b/chapters/04.xml
@@ -1224,12 +1224,12 @@ There is also a different way of building lujvo, or rather phrases which are gra
         <indexterm type="example"><primary>syllabic pronunciations of consonants</primary><secondary>in fu'ivla category attachment</secondary><tertiary>example</tertiary></indexterm> 
       </title>
       <lojbanization>
-        <natlang>spaghetti <comment>from English or Italian</comment></natlang>
+        <natlang>spaghetti <comment>(from English or Italian)</comment></natlang>
         
-        <jbo>spageti <comment>Lojbanize</comment></jbo>
-        <jbo>cidj,r,spageti <comment>prefix long rafsi</comment></jbo>
+        <jbo>spageti <comment>(Lojbanize)</comment></jbo>
+        <jbo>cidj,r,spageti <comment>(prefix long rafsi)</comment></jbo>
         
-        <jbo>dja,r,spageti <comment>prefix short rafsi</comment></jbo>
+        <jbo>dja,r,spageti <comment>(prefix short rafsi)</comment></jbo>
       </lojbanization>
     </example>
     <para>  where 
@@ -1259,13 +1259,13 @@ There is also a different way of building lujvo, or rather phrases which are gra
         <anchor xml:id="c4e7d4"/>
       </title>
       <lojbanization>
-        <natlang>Acer <comment>the scientific name of maple trees</comment></natlang>
+        <natlang>Acer <comment>(the scientific name of maple trees)</comment></natlang>
         
         
-        <jbo>acer <comment>Lojbanize</comment></jbo>
-        <jbo>xaceru <comment>add initial consonant and final vowel</comment></jbo>
-        <jbo>tric,r,xaceru <comment>prefix rafsi</comment></jbo>
-        <jbo>ric,r,xaceru <comment>prefix short rafsi</comment></jbo>
+        <jbo>acer <comment>(Lojbanize)</comment></jbo>
+        <jbo>xaceru <comment>(add initial consonant and final vowel)</comment></jbo>
+        <jbo>tric,r,xaceru <comment>(prefix rafsi)</comment></jbo>
+        <jbo>ric,r,xaceru <comment>(prefix short rafsi)</comment></jbo>
       </lojbanization>
     </example>
     <para>where 
@@ -1291,10 +1291,10 @@ There is also a different way of building lujvo, or rather phrases which are gra
         <anchor xml:id="c4e7d5"/>
       </title>
       <lojbanization>
-        <natlang>brie <comment>from French</comment></natlang>
+        <natlang>brie <comment>(from French)</comment></natlang>
         
-        <jbo>bri <comment>Lojbanize</comment></jbo>
-        <jbo>cirl,r,bri <comment>prefix rafsi</comment></jbo>
+        <jbo>bri <comment>(Lojbanize)</comment></jbo>
+        <jbo>cirl,r,bri <comment>(prefix rafsi)</comment></jbo>
       </lojbanization>
     </example>
     <para>  where 
@@ -1315,8 +1315,8 @@ There is also a different way of building lujvo, or rather phrases which are gra
       <lojbanization>
         <natlang>cobra</natlang>
         
-        <jbo>kobra <comment>Lojbanize</comment></jbo>
-        <jbo>sinc,r,kobra <comment>prefix rafsi</comment></jbo>
+        <jbo>kobra <comment>(Lojbanize)</comment></jbo>
+        <jbo>sinc,r,kobra <comment>(prefix rafsi)</comment></jbo>
       </lojbanization>
     </example>
     <para>  where 
@@ -1337,9 +1337,9 @@ There is also a different way of building lujvo, or rather phrases which are gra
       <lojbanization>
         <natlang>quark</natlang>
         
-        <jbo>kuark <comment>Lojbanize</comment></jbo>
-        <jbo>kuarka <comment>add final vowel</comment></jbo>
-        <jbo>sask,r,kuarka <comment>prefix rafsi</comment></jbo>
+        <jbo>kuark <comment>(Lojbanize)</comment></jbo>
+        <jbo>kuarka <comment>(add final vowel)</comment></jbo>
+        <jbo>sask,r,kuarka <comment>(prefix rafsi)</comment></jbo>
       </lojbanization>
     </example>
     <para> <indexterm type="general-imported"><primary>allowable diphthongs</primary><secondary>in gismu and lujvo contrasted with in fu'ivla</secondary></indexterm>  <indexterm type="general-imported"><primary>allowable diphthongs</primary><secondary>in fu'ivla contrasted with in gismu and lujvo</secondary></indexterm>  <indexterm type="general-imported"><primary>diphthongs</primary><secondary>in fu'ivla</secondary></indexterm>  <indexterm type="general-imported"><primary>fu'ivla</primary><secondary>diphthongs in</secondary></indexterm> where 
@@ -1355,10 +1355,10 @@ There is also a different way of building lujvo, or rather phrases which are gra
         <anchor xml:id="c4e7d8"/>
       </title>
       <lojbanization>
-        <natlang xml:lang="ko">자모 <comment>from Korean</comment></natlang>
-        <jbo>djamo <comment>Lojbanize</comment></jbo>
-        <jbo>lerf,r,djamo <comment>prefix rafsi</comment></jbo>
-        <jbo>ler,l,djamo <comment>prefix rafsi</comment></jbo>
+        <natlang xml:lang="ko">자모 <comment>(from Korean)</comment></natlang>
+        <jbo>djamo <comment>(Lojbanize)</comment></jbo>
+        <jbo>lerf,r,djamo <comment>(prefix rafsi)</comment></jbo>
+        <jbo>ler,l,djamo <comment>(prefix rafsi)</comment></jbo>
       </lojbanization>
     </example>
     <para>where 
@@ -1410,7 +1410,7 @@ The prefix method would render the mathematical concept as
       </title>
       <lojbanization>
         <jbo role="pronunciation">bang,r,blgaria</jbo>
-        <natlang>Bulgarian <comment>in language</comment></natlang>
+        <natlang>Bulgarian <comment>(in language)</comment></natlang>
         
       </lojbanization>
     </example>
@@ -1423,7 +1423,7 @@ The prefix method would render the mathematical concept as
       </title>
       <lojbanization>
         <jbo role="pronunciation">kuln,r,blgaria</jbo>
-        <natlang>Bulgarian <comment>in culture</comment></natlang>
+        <natlang>Bulgarian <comment>(in culture)</comment></natlang>
         
       </lojbanization>
     </example>
@@ -1440,7 +1440,7 @@ The prefix method would render the mathematical concept as
       </title>
       <lojbanization>
         <jbo role="pronunciation">gugd,r,blgaria</jbo>
-        <natlang>Bulgaria <comment>the country</comment></natlang>
+        <natlang>Bulgaria <comment>(the country)</comment></natlang>
       </lojbanization>
     </example>
     <example xml:id="example-random-id-qJGv" role="lojbanization-example">
@@ -1452,7 +1452,7 @@ The prefix method would render the mathematical concept as
       </title>
       <lojbanization>
         <jbo role="pronunciation">bang,r,kore,a</jbo>
-        <natlang>Korean <comment>the language</comment></natlang>
+        <natlang>Korean <comment>(the language)</comment></natlang>
         
       </lojbanization>
     </example>
@@ -1469,7 +1469,7 @@ The prefix method would render the mathematical concept as
       </title>
       <lojbanization>
         <jbo role="pronunciation">kuln,r,kore,a</jbo>
-        <natlang>Korean <comment>the culture</comment></natlang>
+        <natlang>Korean <comment>(the culture)</comment></natlang>
         
       </lojbanization>
     </example>

--- a/chapters/07.xml
+++ b/chapters/07.xml
@@ -1629,7 +1629,7 @@
       <interlinear-gloss>
         <jbo>mi bajykla ti soi vo'i se'u ta</jbo>
         <gloss>I runningly-go to-this [reciprocity] [x3 of this bridi] from-that</gloss>
-        <natlang>I run to this from that and vice versa.</natlang>
+        <natlang>I runningly-go to this from that and vice versa.</natlang>
       </interlinear-gloss>
     </example>
   </section>

--- a/chapters/13.xml
+++ b/chapters/13.xml
@@ -2485,7 +2485,8 @@
         <anchor xml:id="c13e12d7"/>
       </title>
       <interlinear-gloss>
-        <jbo>ru</jbo>
+        <natlang xml:lang="zh">ru<superscript>2</superscript>guo<superscript>3</superscript> ni<superscript>3</superscript> kan<superscript>4</superscript>dao<superscript>4</superscript> wo<superscript>3</superscript> mei<superscript>4</superscript>mei, ni<superscript>3</superscript> yi<superscript>2</superscript>ding<superscript>4</superscript> zhi<superscript>1</superscript>dao<superscript>4</superscript> ta<superscript>1</superscript> huai<superscript>2</superscript>yun<superscript>4</superscript> le</natlang>
+        <gloss>if you see-arrive my younger-sister, you certainly know she pregnant</gloss>
       </interlinear-gloss>
     </example>
     <para>is the equivalent of either 

--- a/chapters/18.xml
+++ b/chapters/18.xml
@@ -763,11 +763,15 @@
         <selmaho>PEhO</selmaho>
         <description>forethought flag</description>
       </cmavo-entry>
-
       <cmavo-entry>
         <cmavo>ku'e</cmavo>
         <selmaho>KUhE</selmaho>
         <description>forethought terminator</description>
+      </cmavo-entry>
+      <cmavo-entry>
+        <cmavo>ma'o</cmavo>
+        <selmaho>MAhO</selmaho>
+        <description>convert operand to operator</description>
       </cmavo-entry>
       <cmavo-entry>
         <cmavo>py.</cmavo>
@@ -783,11 +787,6 @@
         <cmavo>zy.</cmavo>
         <selmaho>BY</selmaho>
         <description>letter <quote>z</quote></description>
-      </cmavo-entry>
-      <cmavo-entry>
-        <cmavo>ma'o</cmavo>
-        <selmaho>MAhO</selmaho>
-        <description>convert operand to operator</description>
       </cmavo-entry>
       <cmavo-entry>
         <cmavo>fy.</cmavo>


### PR DESCRIPTION
Fixes the following issues:
#26 C4. Examples 4.24, 4.26-4.38, 4.46-4.51, 4.52-4.70 are missing content
#32 C7. Example 7.62, line 3, differs from the red book
#52 C18. Section 6 cmavo list: ma'o is in the wrong row
#91 C13. Example 13.89. is missing all but a single word

Three of them are in the "Data" milestone, which means they are not solely XML tag changes. My understanding is the prohibition of "content changes" stated in the TODO file does not apply to content _fixes_ that just restores it to match with v1.0.
