### PR TITLE
.i pei si'o ka'e ku na ku cusku zo cu

### DIFF
--- a/chapters/02.xml
+++ b/chapters/02.xml
@@ -2167,7 +2167,7 @@
         <jbo>
           <sumti>le vi tavla </sumti>
           <elidable>ku</elidable>
-          <elidable elidable="false">cu</elidable>
+          <elidable>cu</elidable>
           <selbri>ba klama</selbri>
         </jbo>
         <gloss>


### PR DESCRIPTION
Since the same section has explained that tense tags make "cu" unnecessary, I think the example should be "le vi tavla ~np~ku cu~/np~ ba klama".

https://mw.lojban.org/papri/CLL,_aka_Reference_Grammar,_Errata#Chapter_2