### PR TITLE
Mizraim => مِصر‎‎ Miṣr

### DIFF
--- a/chapters/04.xml
+++ b/chapters/04.xml
@@ -3006,7 +3006,7 @@ This section contains examples of making and scoring lujvo. First, we will start
           </tr>
           <tr>
             <td><valsi>misro</valsi></td>
-            <td>Egyptian (from <quote xml:lang="he">Mizraim</quote>)</td>
+            <td>Egyptian (from <quote xml:lang="ar">مِصر (Miṣr)</quote>)</td>
           </tr>
           <tr>
             <td><valsi>morko</valsi></td>


### PR DESCRIPTION
Etymology of misro from Mizrahim seems like an unnecessary and surprising detour. Linking it to misrmakes more sense. mu'o mi'e .iesk. 16:47, 10 avgusto 2013 (UTC)

