### PR TITLE
selma'o VOhA and GOhI

### DIFF
--- a/chapters/05.xml
+++ b/chapters/05.xml
@@ -1351,8 +1351,8 @@
     <valsi>troci</valsi>. The other places of the selbri remain unfilled. The trailing sumti 
     <jbophrase>le zarci</jbophrase> and 
     <jbophrase>le zdani</jbophrase> do not occupy selbri places, despite appearances.</para>
-    <para>As a result, the regular mechanisms (involving selma'o VOhA and GOhI, explained in 
-    <xref linkend="chapter-anaphoric-cmavo"/>) for referring to individual sumti of a bridi cannot refer to any of the trailing places of 
+    <para>As a result, the regular mechanisms (involving the vo'a and the go'a-series, explained in 
+    <xref linkend="section-ri-gohi-series"/> and <xref linkend="section-voha-series"/>) for referring to individual sumti of a bridi cannot refer to any of the trailing places of 
     <xref linkend="example-random-id-qjVx"/>, because they are not really 
     <quote>sumti of the bridi</quote> at all.</para>
     <para> <indexterm type="general"><primary>tanru inversion</primary><secondary>where allowed</secondary></indexterm>  <indexterm type="general"><primary>tanru inversion</primary><secondary>in complex tanru</secondary></indexterm> When inverting a more complex tanru, it is possible to invert it only at the most general modifier-modified pair. The only possible inversion of 


### PR DESCRIPTION
Section 8 says "involving selma'o VOhA and GOhI, explained in Chapter 7", but VOhA doesn't appear in Chapter 7. VOhA doesn't even seem to be a selma'o, for that matter. Also, probably GOhI should be GOhA?