### PR TITLE
the quote delimiter {kuot} needs a preceding pause.

### DIFF
--- a/chapters/06.xml
+++ b/chapters/06.xml
@@ -2173,7 +2173,7 @@
         <anchor xml:id="c6e14d4"/>
       </title>
       <interlinear-gloss>
-        <jbo>mi cusku zoi kuot. I'm--John .kuot</jbo>
+        <jbo>mi cusku zoi .kuot. I'm--John .kuot.</jbo>
         <gloss>I express [non-Lojban] &lt; I'm--John &gt;.</gloss>
         <natlang>I say 
         <quote>I'm John</quote>.</natlang>


### PR DESCRIPTION
In section 14, example 1.93, the quote delimiter {kuot} needs a preceding pause.