### PR TITLE
coronal sibilant

### DIFF
--- a/chapters/03.xml
+++ b/chapters/03.xml
@@ -117,7 +117,7 @@
             </td>
             <td><phrase role="X-SAMPA">[S]</phrase>, <phrase role="X-SAMPA">[s`]</phrase>
             </td>
-            <td>an unvoiced coronal sibilant</td>
+            <td>a voiceless postalveolar fricative</td>
           </tr>
           <tr>
             <td><letteral>d</letteral></td>
@@ -159,7 +159,7 @@
             </td>
             <td><phrase role="X-SAMPA">[Z]</phrase>, <phrase role="X-SAMPA">[z`]</phrase>
             </td>
-            <td>a voiced coronal sibilant</td>
+            <td>a voiced postalveolar fricative</td>
           </tr>
           <tr>
             <td><letteral>k</letteral></td>


### PR DESCRIPTION
* Section 2.  The descriptions of ''c'' and ''j'' are listed as "coronal sibilant"s.  The descriptions should read "voiceless postalveolar fricative" and "voiced postalveolar fricative", respectively.  John Cowan: Approved