### PR TITLE
bo grouping => normal grouping?

### DIFF
--- a/chapters/05.xml
+++ b/chapters/05.xml
@@ -2005,7 +2005,7 @@
     <para role="indent">Since only 
     <valsi>pamoi</valsi> is negated, an appropriate inference is that he is some other kind of speaker.</para>
     <para> <indexterm type="general"><primary>negation</primary><secondary>complex examples</secondary></indexterm>  <indexterm type="general"><primary>complex negation</primary><secondary>examples</secondary></indexterm> Here is an assortment of more complex examples showing the interaction of scalar negation with 
-    <valsi>bo</valsi> grouping, 
+    normal grouping, 
     <valsi>ke</valsi> and 
     <valsi>ke'e</valsi> grouping, logical connection, and sumti linked with 
     <valsi>be</valsi> and 
@@ -2042,8 +2042,7 @@
     <para role="indent">Now consider 
     <xref linkend="example-random-id-qjyW"/> and 
     <xref linkend="example-random-id-qjyy"/>, which are equivalent in meaning, but use 
-    <valsi>ke</valsi> grouping and 
-    <valsi>bo</valsi> grouping respectively:</para>
+    normal grouping and <valsi>ke</valsi> grouping respectively:</para>
     <example xml:id="example-random-id-qjyW" role="interlinear-gloss-example">
       <title>
         <anchor xml:id="c5e12d6"/>


### PR DESCRIPTION
Section 12 the text says examples 121 and 122 "use {ke} grouping and {bo} grouping respectively", but it isn't true. Example 121 uses only implicit tanru grouping, while 122 in fact uses {ke} grouping. Also, the text says they are equivalent in meaning, but they aren't (in the first one, {cadzu} groups with {masno}). Perhaps it's missing a {bo}? The translations of examples 121-126 are all affected by this false claim of equivalence.