### PR TITLE
nunkilbra => nunkilca'a

### DIFF
--- a/chapters/05.xml
+++ b/chapters/05.xml
@@ -2294,7 +2294,7 @@
     <table>
       <caption>Example tanru</caption>
           <tr>
-            <td><jbophrase>pinsi nunkilbra</jbophrase></td>
+            <td><jbophrase>pinsi nunkilca'a</jbophrase></td>
             <td>pencil sharpener</td>
             <td>Hun</td>
             <td></td>


### PR DESCRIPTION
{bra} can't be a rafsi for {cabra} since in other sections CLL uses {bralo'i} and {brablo}