### PR TITLE
"ZEhA [PU NAI ]" should be enclosed in parentheses

### DIFF
--- a/chapters/21.xml
+++ b/chapters/21.xml
@@ -7843,7 +7843,7 @@ the 900 series rules are found in the lexer.  */
         <term>time 
         <subscript>1030</subscript>=</term>
         <listitem>
-          <para>ZI &amp; time-offset ... &amp; ZEhA [PU [NAI]] &amp; interval-property ... 
+          <para>ZI &amp; time-offset ... &amp; (ZEhA [PU [NAI]]) &amp; interval-property ... 
           <anchor xml:id="b1033"/>
           <anchor xreflabel="BNF rule #1033" xml:id="cll_bnf-1033"/>
           <!-- <xref linkend="cll_yacc-1033"/> --></para>


### PR DESCRIPTION
In the BNF grammar, in the rule time_1030, the "ZEhA [PU NAI ]" should be enclosed in parentheses.