### PR TITLE
semicolon => comma after "(say, a spelling error)"

### DIFF
--- a/chapters/15.xml
+++ b/chapters/15.xml
@@ -1525,7 +1525,7 @@
     <para>Many of these forms have a counterpart in the various examples that we've discussed under logical negation. Metalinguistic negation doesn't claim that the sentence is false or true, though. Rather, it claims that, due to some error in the statement, 
     <quote>true</quote> and 
     <quote>false</quote> don't really apply.</para>
-    <para>Because one can metalinguistically negate a true statement intending a non-contradictory correction (say, a spelling error); we need a way (or ways) to metalinguistically negate a statement which is independent of our logical negation schemes using 
+    <para>Because one can metalinguistically negate a true statement intending a non-contradictory correction (say, a spelling error), we need a way (or ways) to metalinguistically negate a statement which is independent of our logical negation schemes using 
     <valsi>na</valsi>, 
     <valsi>na'e</valsi> and kin. The cmavo 
     <valsi>na'i</valsi> is assigned this function. If it is present in a statement, it indicates metalinguistically that something in the statement is incorrect. This metalinguistic negation must override any evaluation of the logic of the statement. It is equally allowed in both positive and negative statements.</para>


### PR DESCRIPTION
Section 10, three paragraphs after example 10.14, there's a semicolon which should be a comma after "(say, a spelling error)".

John Cowan: Approved