### PR TITLE
comma is "." in IPA and X-SAMPA

### DIFF
--- a/chapters/03.xml
+++ b/chapters/03.xml
@@ -87,8 +87,8 @@
           </tr>
           <tr>
             <td><letteral>,</letteral></td>
-            <td>-</td>
-            <td>-</td>
+            <td>.</td>
+            <td>.</td>
             <td>the syllable separator</td>
           </tr>
           <tr>


### PR DESCRIPTION
In section 3.2, the comma should (probably) be represented by the IPA notation [.], as the period is used in IPA to denote syllable breaks.

John Cowan: Approved