### PR TITLE
Obvious errata (chapters 3, 9, 11, 14, 15, 17)

### DIFF
--- a/chapters/03.xml
+++ b/chapters/03.xml
@@ -857,7 +857,7 @@
             <td><morphology>zv</morphology></td>
           </tr>
     </informaltable>
-    <para>Lest this list seem almost random, a pairing of voiced and unvoiced equivalent vowels will show significant patterns which may help in learning:</para>
+    <para>Lest this list seem almost random, a pairing of voiced and unvoiced equivalent consonants will show significant patterns which may help in learning:</para>
     <informaltable class="noborder">
           <tr>
             <td><morphology>pl</morphology></td>

--- a/chapters/09.xml
+++ b/chapters/09.xml
@@ -1982,7 +1982,7 @@
     <xref linkend="example-random-id-qMSb"/>, because 
     <valsi>ke</valsi>&hellip;<valsi>ke'e</valsi> cannot extend across more than one sentence. It would also be possible to change the 
     <jbophrase>.ijeseri'abo</jbophrase> to 
-    <jbophrase>.ije seri'a</jbophrase>, which would show that the 
+    <jbophrase>.ije ri'a</jbophrase>, which would show that the 
     <valsi>tu'e</valsi>&hellip;<valsi>tu'u</valsi> portion was an effect, but would not pin down the 
     <jbophrase>mi bevri le dakli</jbophrase> portion as the cause. It is legal for a modal (or a tense; see 
     <xref linkend="chapter-tenses"/>) to modify the whole of a 

--- a/chapters/11.xml
+++ b/chapters/11.xml
@@ -498,8 +498,8 @@
         <anchor xml:id="c11e4d4"/>
       </title>
       <interlinear-gloss>
-        <jbo>le ka do xunre [kei] cu cnino mi</jbo>
-        <gloss>The property-of your being-red -- -- is-new to--me.</gloss>
+        <jbo>le du'u do xunre [kei] cu cnino mi</jbo>
+        <gloss>The proposition-of you being-red -- -- is-new to--me.</gloss>
         <natlang>Your redness is new to me.</natlang>
       </interlinear-gloss>
     </example>

--- a/chapters/14.xml
+++ b/chapters/14.xml
@@ -2351,7 +2351,7 @@
         <gloss>That-named James [plus] that-named Mary [joint]</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
-        <jbo>… .e la djordj. ce'e la martas. prami</jbo>
+        <jbo>… je la djordj. ce'e la martas. prami</jbo>
         <gloss>… and that-named George [plus] that-named Martha loves.</gloss>
       </interlinear-gloss>
     </example>
@@ -2493,7 +2493,7 @@
       <title>
         <anchor xml:id="c14e15d8"/>
       </title>
-      <jbophrase>nu'i joigi mi bau la lojban gi do bau la gliban. nu'u casnu</jbophrase>
+      <jbophrase>nu'i joigi mi bau la lojban. gi do bau la gliban. nu'u casnu</jbophrase>
     </example>
     <para role="indent"> <indexterm type="general"><primary>respectively</primary><secondary>with different relationships</secondary></indexterm>  <indexterm type="general"><primary>tagged sumti termsets</primary><secondary>connecting with non-logical forethought connectives</secondary></indexterm>  <indexterm type="general"><primary>non-logical forethought termsets</primary><secondary>connecting tagged sumti</secondary></indexterm> Non-logical forethought termsets are also useful when the things to be non-logically connected are sumti preceded with tense or modal (BAI) tags:</para>
     
@@ -2970,7 +2970,7 @@ Ugh. (Or in Lojban: <valsi>.a'u</valsi><valsi>nai</valsi><valsi>sai</valsi><vals
         <anchor xml:id="c14e17d4"/>
       </title>
       <interlinear-gloss>
-        <jbo>li re ge su'i gi pi'i re du li vo</jbo>
+        <jbo>li re gu'e su'i gi pi'i re du li vo</jbo>
         <gloss>The-number two both plus and times two equals the-number four.</gloss>
         <natlang>Both <dbinlinemath>2 + 2 = 4</dbinlinemath> and <dbinlinemath>2 x 2 = 4</dbinlinemath>.</natlang>
       </interlinear-gloss>

--- a/chapters/15.xml
+++ b/chapters/15.xml
@@ -720,7 +720,7 @@
         <listitem><para>na'e klama becomes nalkla</para></listitem>
         <listitem><para>na'e cadzu klama becomes naldzukla</para></listitem>
         <listitem><para>na'e sutra cadzu klama becomes nalsu'adzukla</para></listitem>
-        <listitem><para>nake sutra cadzu ke'e klama becomes nalsu'adzuke'ekla</para></listitem>
+        <listitem><para>na'e ke sutra cadzu ke'e klama becomes nalsu'adzuke'ekla</para></listitem>
       </itemizedlist>
     </example>
     <para role="indent">Note: 

--- a/chapters/17.xml
+++ b/chapters/17.xml
@@ -835,9 +835,9 @@
     </example>
     <para role="indent">Since the Lojban sentence has only four 
     <letteral>e</letteral> lerfu rather than fourteen, the translation is not a literal one &ndash; but 
-    <xref linkend="example-random-id-pbDf"/> is a Lojban truth just as 
+    <xref linkend="example-random-id-UT1J"/> is a Lojban truth just as 
     <xref linkend="example-random-id-tvHm"/> is an English truth. Coincidentally, the colloquial English translation of 
-    <xref linkend="example-random-id-pbDf"/> is also true!</para>
+    <xref linkend="example-random-id-UT1J"/> is also true!</para>
     <para> <indexterm type="lojban-word"><primary>la'e</primary></indexterm>  <indexterm type="general"><primary>la'e lu</primary><secondary>compared with me'o</secondary></indexterm>  <indexterm type="general"><primary>me'o</primary><secondary>compared with la'e lu</secondary></indexterm>  <indexterm type="general"><primary>representing lerfu</primary><secondary>lu contrasted with me'o</secondary></indexterm>  <indexterm type="general"><primary>lu</primary><secondary>contrasted with me'o for representing lerfu</secondary></indexterm>  <indexterm type="general"><primary>me'o</primary><secondary>contrasted with lu…li'u for representing lerfu</secondary></indexterm>  <indexterm type="general"><primary>me'o</primary><secondary>contrasted with quotation for representing lerfu</secondary></indexterm>  <indexterm type="general"><primary>quotation</primary><secondary>contrasted with me'o for representing lerfu</secondary></indexterm> The reader might be tempted to use quotation with 
     <valsi>lu</valsi>&hellip;<valsi>li'u</valsi> instead of 
     <valsi>me'o</valsi>, producing:</para>
@@ -1138,7 +1138,7 @@
     <quote>character codes</quote>) into selected lerfu, digits, and punctuation marks (collectively called 
     
     
-    <quote>characters</quote>). Historically, these character sets have only covered the English alphabet and a few selected punctuation marks. International efforts have now created Unicode, a unified character set that can represent essentially all the characters in essentially all the world's writing systems. Lojban can take advantage of these encoding schemes by using the cmavo 
+    <quote>characters</quote>). Historically, each of these character sets has only covered a particular writing system. International efforts have now created Unicode, a unified character set that can represent essentially all the characters in essentially all the world's writing systems. Lojban can take advantage of these encoding schemes by using the cmavo 
     
     
     <valsi>se'e</valsi> (of selma'o BY). This cmavo is conventionally followed by digit cmavo of selma'o PA representing the character code, and the whole string indicates a single character in some computerized character set:</para>


### PR DESCRIPTION
This is a mass commit of fixes from https://mw.lojban.org/papri/CLL,_aka_Reference_Grammar,_Errata that I'd be surprised to hear anyone find controversial.

Chapter 3

* Section 7. In between the shaded boxes, "a pairing of voiced and unvoiced equivalent vowels" should read "a pairing of voiced and unvoiced equivalent consonants".

Chapter 9

* Section 11, description of the meaning of ".ije seri'a tu'e" contradicts the explanation of Example 9.9, which would suggest ".ije ri'a tu'e".

Chapter 11

* Section 4: The use of ka in Example 4.4 (page 259) is erroneous; it should be du'u. --John Cowan

Chapter 14

* Section 14, example 14.15 is not grammatical (according to jbofi'e and camxes) because it says "pe'e .e" when it should say "pe'e je".
* Section 15, example 15.8 is missing a dot after "la lojban".
* Section 17, example 17.4 is wrong. The section explains that mekso operators can be logically connected using {gu'e ... gi ...}, but this example tries to connect them with {ge ... gi ...}. Replace {ge} with {gu'e} in the example to correct it.

Chapter 15

* Section 4, example 4.12 /nake/na'eke/

Chapter 17

* Section 10. After Example 10.4.5, the reference to Example 10.4 should be instead to Example 10.4.5.
* In section 13, the first paragraph states "Historically, these character sets have only covered the English alphabet and a few selected punctuation marks.", which is incorrect. There have been multitudes of character sets for writing systems other than the English alphabet.
** Change to something along the line of "Historically, each of these character sets has only covered a particular writing system."