### PR TITLE
Chapter 8 errata: {co'o [le] xirma}, {coi noi mo .cmev.}

### DIFF
--- a/chapters/08.xml
+++ b/chapters/08.xml
@@ -1409,14 +1409,7 @@
         <natlang>Welcome, Frank and George!</natlang>
       </interlinear-gloss>
     </example>
-    <para role="indent">Note that 
-    <xref linkend="example-random-id-qMGj"/> says farewell to something which doesn't really have to be a horse, something that the speaker simply thinks of as being a horse, or even might be something (a person, for example) who is named 
-    <quote>Horse</quote>. In a sense, 
-    <xref linkend="example-random-id-qMGj"/> is ambiguous between 
-    <jbophrase>co'o le xirma</jbophrase> and 
-    <jbophrase>co'o la xirma</jbophrase>, a relatively safe semantic ambiguity, since names are ambiguous in general: saying 
-    <quote>George</quote> doesn't distinguish between the possible Georges.</para>
-    <para>Similarly, 
+    <para>
     <xref linkend="example-random-id-qMG8"/> can be thought of as an abbreviation of:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-oWPU">
       <title>
@@ -1428,10 +1421,14 @@
         <quote>Frank</quote>.</gloss>
       </interlinear-gloss>
     </example>
+    <para>Similarly,
+    <xref linkend="example-random-id-qMGj"/> is short for
+    <jbophrase>co'o le xirma</jbophrase>.
+    </para>
     <para role="indent">Syntactically, vocative phrases are a kind of free modifier, and can appear in many places in Lojban text, generally at the beginning or end of some complete construct; or, as in 
     <xref linkend="example-random-id-qMG8"/> to 
     <xref linkend="example-random-id-qmgM"/>, as sentences by themselves.</para>
-    <para> <indexterm type="general"><primary>vocative phrase with name</primary><secondary>placement of relative clause on</secondary></indexterm>  <indexterm type="general"><primary>relative clauses</primary><secondary>placement with vocative phrases</secondary></indexterm>  <indexterm type="general"><primary>vocative phrases</primary><secondary>relative clauses on</secondary></indexterm>  <indexterm type="general"><primary>relative clauses</primary><secondary>on vocative phrases</secondary></indexterm> As can be seen, the form of vocative phrases is similar to that of sumti, and as you might expect, vocative phrases allow relative clauses in various places. In vocative phrases which are simple names (after the vocative words), any relative clauses must come just after the names:</para>
+    <para> <indexterm type="general"><primary>vocative phrases</primary><secondary>relative clauses on</secondary></indexterm><indexterm type="general"><primary>relative clauses</primary><secondary>on vocative phrases</secondary></indexterm> As can be seen, the form of vocative phrases is similar to that of sumti, and as you might expect, vocative phrases allow relative clauses in various places. A vocative phrase can have relative clauses either before or after the selbri or name; both forms have the same meaning. Here are some examples:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-xECX">
       <title>
         <anchor xml:id="c8e9d5"/>
@@ -1445,7 +1442,6 @@
     <para role="indent">The restrictive relative clause in 
     
     <xref linkend="example-random-id-xECX"/> suggests that there is some other Frank (perhaps on the Green Team) from whom this Frank, the one the speaker is greeting, must be distinguished.</para>
-    <para> <indexterm type="general"><primary>vocative phrase with selbri</primary><secondary>placement of relative clause on</secondary></indexterm> A vocative phrase containing a selbri can have relative clauses either before or after the selbri; both forms have the same meaning. Here are some examples:</para>
     
     <example xml:id="example-random-id-qmgV" role="interlinear-gloss-example">
       <title>


### PR DESCRIPTION
Errata from https://mw.lojban.org/papri/CLL,_aka_Reference_Grammar,_Errata

Chapter 8

* Section 9, example 9.2 is ''co'o xirma''. Then, ''Note that Example 9.2 says farewell to something which doesn’t really have to be a horse, something that the speaker simply thinks of as being a horse, or even might be something (a person, for example) who is named "Horse". In a sense, Example 9.2 is ambiguous between "co'o le xirma" and "co'o la xirma"''. Is this true?
** Yes, in the sense that all uses of "le" ''might'' mean "la".  But it's probably more confusing than it's worth.  Truncate after "thinks of as being a horse".  --John Cowan
** Just truncating it there would be too awkward. Reworded to mention {le} by name instead of "thinks of as being", and moved after the cmevla example.
* Section 9 says ''In vocative phrases which are simple names (after the vocative words), any relative clauses must come just after the names''. This isn't true. Relative clauses can go between the vocative and the cmevla.  [[Approved Erratum|John Cowan: Approved]]  Drop it; it reflects an earlier state of the language.