### PR TITLE
Chapter 16 erratum: remove prenex after ijek

### DIFF
--- a/chapters/16.xml
+++ b/chapters/16.xml
@@ -1335,8 +1335,8 @@
         <gloss>For-each-thing : I love it, and</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
-        <jbo>naku zo'u do prami da</jbo>
-        <gloss>it-is-false-that : you love (the-same)-it.</gloss>
+        <jbo>naku do prami da</jbo>
+        <gloss>it-is-false-that you love (the-same)-it.</gloss>
         <natlang>For each thing: I love it, and it is false that you love (the same) it.</natlang>
       </interlinear-gloss>
     </example>


### PR DESCRIPTION
Errata from https://mw.lojban.org/papri/CLL,_aka_Reference_Grammar,_Errata

Chapter 16
* Section 10, ex. 10.5 and 10.6 have a prenex, "naku zo'u", after an ijek. This is not allowed by the grammar. It could be fixed by removing the "zo'u" and using "naku" outside the prenex, although this is only explained in the following Section 11.
** This is a big problem, and I'm not sure what should be fixed.  --[[User:John Cowan|John Cowan]]  '''NOFIX'''
** Fixed by removing zo'u