### PR TITLE
Chapter 18 errata: rafsi for {fi'u} etc

### DIFF
--- a/chapters/18.xml
+++ b/chapters/18.xml
@@ -2805,12 +2805,12 @@
         <anchor xml:id="c18e17d5"/>
       </title>
       <interlinear-gloss>
-        <jbo>li re ge su'i gi pi'i re du li vo</jbo>
+        <jbo>li re gu'e su'i gi pi'i re du li vo</jbo>
         <gloss>the-number two both plus and times two equals the-number four.</gloss>
         <dbmath>Both 2 + 2 = 4 and 2 × 2 = 4.</dbmath>
       </interlinear-gloss>
     </example>
-    <para role="indent">Here is a classic example of operand logical connection:</para>
+    <para role="indent">Here is a classic example of operator logical connection:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k36J">
       <title>
         <anchor xml:id="c18e17d6"/>
@@ -3440,8 +3440,8 @@
     <valsi>fi'u</valsi> does not have a rafsi as such, it is closely related to the gismu 
     
     <valsi>frinu</valsi>, meaning 
-    <quote>fraction</quote>; therefore, in a context of numeric rafsi, you can use any of the rafsi for 
-    <valsi>frinu</valsi> to indicate a fraction slash.</para>
+    <quote>fraction</quote>; therefore, in a context of numeric rafsi, you can use
+    <valsi>frinu</valsi>'s rafsi to indicate a fraction slash.</para>
     <para> <indexterm type="general"><primary>rafsi</primary><secondary>conventional meaning for cu'o</secondary></indexterm> A similar convention is used for the cmavo 
     <valsi>cu'o</valsi> of selma'o MOI, which is closely related to 
     
@@ -3894,7 +3894,7 @@
           </cmavo-entry>
           <cmavo-entry>
             <cmavo>fi'u</cmavo>
-            <rafsi>fi'u (from frinu; see <xref linkend="section-explicit-operator-precedence"/>)</rafsi>
+            <rafsi>friny (from frinu; see <xref linkend="section-explicit-operator-precedence"/>)</rafsi>
             <description>fraction (not division)</description>
           </cmavo-entry>
           <cmavo-entry>


### PR DESCRIPTION
Errata from https://mw.lojban.org/papri/CLL,_aka_Reference_Grammar,_Errata

Chapter 18

* In section 17, example 17.5, {gi} should be replaced by {gu'e}, because mekso operators are to be connected by guheks. This is essentially the same mistake as in example 14/17.4.
* In section 17, at the bottom of page 454, the quadratic formula should be described as a classic example of operator logical connection, not operand.
* Section 21 states that the rafsi of "frinu" may be used as rafsi for "fi'u"; however, "frinu" lost both of its short rafsi in the Reallocation, so this really isn't very useful. The table below lists "fi'u" as a rafsi usable for "fi'u", therefore of "frinu"; the gimste lists "fi'u" as a rafsi of "cfipu".
** This is a serious problem which needs some thought.  There needs to be a rafsi for fi'u somehow.  --John Cowan  '''NOFIX'''
** simply use the long rafsi mu'o mi'e La Gleki