### PR TITLE
lei	ratcu	poi	zvati	le	panka cu	so'umei	lo'i	ratcu

### DIFF
--- a/chapters/18.xml
+++ b/chapters/18.xml
@@ -1998,7 +1998,7 @@
         <gloss>The-mass-of rats which are-in the park</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
-        <jbo>… cu so'umei lo'i ratcu</jbo>
+        <jbo>… cu so'umei fo lo'i ratcu</jbo>
         <gloss>… - are-a-fewsome-with-respect-to the-set-of rats.</gloss>
         <natlang>The rats in the park are a small number of all the rats there are.</natlang>
       </interlinear-gloss>


### PR DESCRIPTION
* In section 11, "lei ratcu poi zvati le panka cu so'umei fo lo'i ratcu", but there is no 4th place of mei.
** Remove the "fo";
*** la gleki:
**** This introduced two more problems.
***** First, the part "However, when the number expressed before -mei is an objective indefinite number of the kind explained in Section 18.8, a slightly different place structure is required: x1 is a mass formed from a set x2 of n members, one or more of which is/are x3, measured relative to the set x4." became useless.
***** Secondly, the following phrase "the x2 and x3 places are vacant, and the x4 place is filled by lo'i ratcu, which (because no quantifiers are explicitly given) means “the whole of the set of all those things which are rats”, or simply “the set of all rats.”" became incorrect. I suggest restoring {fo}.
