### PR TITLE
cecla =>celgau

### DIFF
--- a/chapters/10.xml
+++ b/chapters/10.xml
@@ -3082,7 +3082,7 @@
         <indexterm type="example"><primary>on two occasions</primary></indexterm>
       </title>
       <interlinear-gloss>
-        <jbo>mi reroi pi'u xaroi cecla</jbo>
+        <jbo>mi reroi pi'u xaroi celgau</jbo>
         <gloss>I [twice] [cross-product] [six-times] shoot</gloss>
       </interlinear-gloss>
       <interlinear-gloss>


### PR DESCRIPTION
Section 21, example 21.1 doesn't seem to parallel the English gloss and translation: the Lojban version implies that "I throw the gun", and not "I fire the gun".