### PR TITLE
"le vi tavla [ku] [cu] ba klama".

### DIFF
--- a/chapters/02.xml
+++ b/chapters/02.xml
@@ -2167,7 +2167,7 @@
         <jbo>
           <sumti>le vi tavla </sumti>
           <elidable>ku</elidable>
-          <elidable elidable="false">cu</elidable>
+          <elidable>cu</elidable>
           <selbri>ba klama</selbri>
         </jbo>
         <gloss>


### PR DESCRIPTION
Example 17.9 in dag-cll as of 2012-05-05 is "le vi tavla [ku] cu ba klama". Since the same section has explained that tense tags make "cu" unnecessary, I think the example should be "le vi tavla [ku] [cu] ba klama".