### PR TITLE
{o} is uttered like "o" in "choice"

### DIFF
--- a/chapters/02.xml
+++ b/chapters/02.xml
@@ -133,8 +133,8 @@
     <quote>let</quote>, 
     <letteral>i</letteral> as in 
     <quote>machine</quote>, 
-    <letteral>o</letteral> as in 
-    <quote>dome</quote> and 
+    <letteral>o</letteral> as <quote>o</quote> in 
+    <quote>choice</quote> and 
     <letteral>u</letteral> as in 
     <quote>flute</quote>. 
     <letteral>y</letteral> is pronounced as the sound called 


### PR DESCRIPTION
Section 2.2 paragraph 2 says "o as in “dome”" but Australian/British English pronounces "dome" as per http://howjsay.com/index.php?word=dome&submit=Submit (i.e. a diphthong, which would be incorrect). This may result in many readers learning the wrong pronunciation of Lojban.
This sort of issue also exists in the "Level 0 Booklet" publication.
There must be a better example word that has the correct "o" for all dialects of English - is "lozenge" a good word?
At the very least, specify which dialect is intended.