### PR TITLE
zmadu4 is x7 of klamau

### DIFF
--- a/chapters/12.xml
+++ b/chapters/12.xml
@@ -1089,6 +1089,7 @@ On the other hand, the lujvo
       <para><definition><content>nu1 is the event of k1's coming/going to k2 from k3 via route k4 by means k5.</content></definition></para>
     </example>
     <para role="indent">Here the first place of 
+    <valsi valid='maybe'>nunklama</valsi> is the first and only place of 
     <valsi>nu</valsi>, and the other five places have been pushed down by one to occupy the second through the sixth places. Full information on 
     <valsi>nu</valsi>, as well as the other abstractors mentioned in this section, is given in 
     <xref linkend="chapter-abstractions"/>.</para>
@@ -1642,9 +1643,9 @@ On the other hand, the lujvo
       <para>
       <valsi valid='maybe'>klamau</valsi>: z1, more than z2, goes to k2 from k3 via k4 by means of k5 by amount z4</para>
       <para>
-      <valsi valid='maybe'>selklamau</valsi>: z1, more than z2, is gone to by k1 from k3 via k4 by means of k5</para>
+      <valsi valid='maybe'>selklamau</valsi>: z1, more than z2, is gone to by k1 from k3 via k4 by means of k5 by amount z4</para>
       <para>
-      <valsi valid='maybe'>terklamau</valsi>: z1, more than z2, is an origin point from destination k2 for k1's going via k4 by means of k5</para>
+      <valsi valid='maybe'>terklamau</valsi>: z1, more than z2, is an origin point from destination k2 for k1's going via k4 by means of k5 by amount z4</para>
     </example>
     <para role="noindent">(See 
     <xref linkend="chapter-abstractions"/> for the way in which this problem is resolved when lujvo aren't used.)</para>

--- a/chapters/12.xml
+++ b/chapters/12.xml
@@ -1645,7 +1645,7 @@ On the other hand, the lujvo
       <para>
       <valsi valid='maybe'>selklamau</valsi>: z1, more than z2, is gone to by k1 from k3 via k4 by means of k5 by amount z4</para>
       <para>
-      <valsi valid='maybe'>terklamau</valsi>: z1, more than z2, is an origin point from destination k2 for k1's going via k4 by means of k5 by amount z4</para>
+      <valsi valid='maybe'>terklamau</valsi>: z1, more than z2, is an origin point for destination k2 for k1's going via k4 by means of k5 by amount z4</para>
     </example>
     <para role="noindent">(See 
     <xref linkend="chapter-abstractions"/> for the way in which this problem is resolved when lujvo aren't used.)</para>

--- a/chapters/12.xml
+++ b/chapters/12.xml
@@ -1089,7 +1089,6 @@ On the other hand, the lujvo
       <para><definition><content>nu1 is the event of k1's coming/going to k2 from k3 via route k4 by means k5.</content></definition></para>
     </example>
     <para role="indent">Here the first place of 
-    <valsi valid='maybe'>nunklama</valsi> is the first and only place of 
     <valsi>nu</valsi>, and the other five places have been pushed down by one to occupy the second through the sixth places. Full information on 
     <valsi>nu</valsi>, as well as the other abstractors mentioned in this section, is given in 
     <xref linkend="chapter-abstractions"/>.</para>
@@ -1641,7 +1640,7 @@ On the other hand, the lujvo
       <para>
       <valsi valid='maybe'>selnelcymau</valsi>: z1, more than z2, is liked by n1 in amount z4</para>
       <para>
-      <valsi valid='maybe'>klamau</valsi>: z1, more than z2, goes to k2 from k3 via k4 by means of k5</para>
+      <valsi valid='maybe'>klamau</valsi>: z1, more than z2, goes to k2 from k3 via k4 by means of k5 by amount z4</para>
       <para>
       <valsi valid='maybe'>selklamau</valsi>: z1, more than z2, is gone to by k1 from k3 via k4 by means of k5</para>
       <para>
@@ -1651,7 +1650,7 @@ On the other hand, the lujvo
     <xref linkend="chapter-abstractions"/> for the way in which this problem is resolved when lujvo aren't used.)</para>
     <para>The ordering rule places the things being compared first, and the other seltau places following. Unfortunately the z4 place, which expresses by how much one entity exceeds the other, is displaced into a lujvo place whose number is different for each lujvo. For example, while 
     <valsi valid='maybe'>nelcymau</valsi> has z4 as its fourth place, 
-    <valsi valid='maybe'>klamau</valsi> has it as its sixth place. In any sentence where a difficulty arises, this amount-place can be redundantly tagged with 
+    <valsi valid='maybe'>klamau</valsi> has it as its seventh place. In any sentence where a difficulty arises, this amount-place can be redundantly tagged with 
     <valsi>vemau</valsi> (for 
     <valsi>zmadu</valsi>) or 
     <valsi>veme'a</valsi> (for 


### PR DESCRIPTION
Section 12, example 12.91 and the text that follows: "klamau: z1, more than z2, goes to k2 from k3 via k4 by means of k5 ... For example, while nelcymau has z4 as its fourth place, klamau has it as its sixth place."

* la gleki:
** The definition of klamau has k5 as its sixth place. I suggest append " by amount z4" to the definition of klamau.