### PR TITLE
Chapter 5, sec. 14 The 3-letter language abbreviations were probably used to save space

### DIFF
--- a/chapters/05.xml
+++ b/chapters/05.xml
@@ -2245,44 +2245,7 @@
     <title><anchor xml:id="c5s14"/>Some types of asymmetrical tanru</title>
     
     <para> <indexterm type="general"><primary>tanru</primary><secondary>asymmetrical</secondary></indexterm>  <indexterm type="general"><primary>asymmetrical tanru</primary></indexterm> This section and 
-    <xref linkend="section-symmetric-tanru"/> contain some example tanru classified into groups based on the type of relationship between the modifying seltau and the modified tertau. All the examples are paralleled by compounds actually observed in various natural languages. In the tables which follow, each group is preceded by a brief explanation of the relationship. The tables themselves contain a tanru, a literal gloss, an indication of the languages which exhibit a compound analogous to this tanru, and (for those tanru with no English parallel) a translation.</para>
-    <para> <indexterm type="general"><primary>languages</primary><secondary>abbreviations for</secondary></indexterm> Here are the 3-letter abbreviations used for the various languages (it is presumed to be obvious whether a compound is found in English or not, so English is not explicitly noted):</para>
-    <para>
-    <informaltable>
-      <colgroup/>
-      <tr>
-          <td>Aba</td><td><para>Abazin</para></td>
-          <td>Chi</td><td><para>Chinese</para></td>
-          <td>Ewe</td><td><para>Ewe</para></td>
-          <td>Fin</td><td><para>Finnish</para></td>
-        </tr>
-      <tr>
-          <td>Geo</td><td><para>Georgian</para></td>
-          <td>Gua</td><td><para>Guarani</para></td>
-          <td>Hop</td><td><para>Hopi</para></td>
-          <td>Hun</td><td><para>Hungarian</para></td>
-        </tr>
-      <tr>
-          <td>Imb</td><td><para>Imbabura Quechua</para></td>
-          <td>Kar</td><td><para>Karaitic</para></td>
-          <td>Kaz</td><td><para>Kazakh</para></td>
-          <td>Kor</td><td><para>Korean</para></td>
-        </tr>
-      <tr>
-          <td>Mon</td><td><para>Mongolian</para></td>
-          <td>Qab</td><td><para>Qabardian</para></td>
-          <td>Que</td><td><para>Quechua</para></td>
-          <td>Rus</td><td><para>Russian</para></td>
-        </tr>
-      <tr>
-          <td>Skt</td><td><para>Sanskrit</para></td>
-          <td>Swe</td><td><para>Swedish</para></td>
-          <td>Tur</td><td><para>Turkish</para></td>
-          <td>Udm</td><td><para>Udmurt</para></td>
-        </tr>
-    </informaltable>
-    </para>
-    <para>Any lujvo or fu'ivla used in a group are glossed at the end of that group.</para>
+    <xref linkend="section-symmetric-tanru"/> contain some example tanru classified into groups based on the type of relationship between the modifying seltau and the modified tertau. All the examples are paralleled by compounds actually observed in various natural languages. In the tables which follow, each group is preceded by a brief explanation of the relationship. The tables themselves contain a tanru, a literal gloss, the languages which exhibit a compound analogous to this tanru, and (for those tanru with no English parallel) a translation.</para>
     <para> <indexterm type="general"><primary>asymmetrical tanru</primary><secondary>definition</secondary></indexterm> The tanru discussed in this section are asymmetrical tanru; that is, ones in which the order of the terms is fundamental to the meaning of the tanru. For example, 
     
     <jbophrase>junla dadysli</jbophrase>, or 
@@ -2296,49 +2259,49 @@
           <tr>
             <td><jbophrase>pinsi nunkilbra</jbophrase></td>
             <td>pencil sharpener</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>zgike nunctu</jbophrase></td>
             <td>music instruction</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>mirli nunkalte</jbophrase></td>
             <td>deer hunting</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>finpe nunkalte</jbophrase></td>
             <td>fish hunting</td>
-            <td>Tur,Kor,Udm,Aba</td>
+            <td>Turkish,Korean,Udmurt,Abazin</td>
             <td>fishing</td>
           </tr>
           <tr>
             <td><jbophrase>smacu terkavbu</jbophrase></td>
             <td>mousetrap</td>
-            <td>Tur,Kor,Hun,Udm,Aba</td>
+            <td>Turkish,Korean,Hungarian,Udmurt,Abazin</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>zdani turni</jbophrase></td>
             <td>house ruler</td>
-            <td>Kar</td>
+            <td>Karaitic</td>
             <td>host</td>
           </tr>
           <tr>
             <td><jbophrase>zerle'a nunte'a</jbophrase></td>
             <td>thief fear</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>fear of thieves</td>
           </tr>
           <tr>
             <td><jbophrase>cevni zekri</jbophrase></td>
             <td>god crime</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>offense against the gods</td>
           </tr>
     </table>
@@ -2370,43 +2333,43 @@
           <tr>
             <td><jbophrase>karda mulgri</jbophrase></td>
             <td>card pack</td>
-            <td>Swe</td>
+            <td>Swedish</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>rokci derxi</jbophrase></td>
             <td>stone heap</td>
-            <td>Swe</td>
+            <td>Swedish</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>tadni girzu</jbophrase></td>
             <td>student group</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>remna girzu</jbophrase></td>
             <td>human-being group</td>
-            <td>Qab</td>
+            <td>Qabardian</td>
             <td>group of people</td>
           </tr>
           <tr>
             <td><jbophrase>cpumi'i lijgri</jbophrase></td>
             <td>tractor column</td>
-            <td>Qab</td>
+            <td>Qabardian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>cevni jenmi</jbophrase></td>
             <td>god army</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>cevni prenu</jbophrase></td>
             <td>god folk</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
     </table>
@@ -2427,7 +2390,7 @@
           <tr>
             <td><jbophrase>carvi dirgo</jbophrase></td>
             <td>raindrop</td>
-            <td>Tur,Kor,Hun,Udm,Aba</td>
+            <td>Turkish,Korean,Hungarian,Udmurt,Abazin</td>
             <td></td>
           </tr>
           <tr>
@@ -2443,49 +2406,49 @@
           <tr>
             <td><jbophrase>junla dadysli</jbophrase></td>
             <td>clock pendulum</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>purdi vorme</jbophrase></td>
             <td>garden door</td>
-            <td>Qab</td>
+            <td>Qabardian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>purdi bitmu</jbophrase></td>
             <td>garden wall</td>
-            <td>Que</td>
+            <td>Quechua</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>moklu skapi</jbophrase></td>
             <td>mouth skin</td>
-            <td>Imb</td>
+            <td>Imbabura Quechua</td>
             <td>lips</td>
           </tr>
           <tr>
             <td><jbophrase>nazbi kevna</jbophrase></td>
             <td>nose hole</td>
-            <td>Imb</td>
+            <td>Imbabura Quechua</td>
             <td>nostril</td>
           </tr>
           <tr>
             <td><jbophrase>karce xislu</jbophrase></td>
             <td>automobile wheel</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>jipci pimlu</jbophrase></td>
             <td>chicken feather</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>vinji rebla</jbophrase></td>
             <td>airplane tail</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
     </table>
@@ -2506,19 +2469,19 @@
           <tr>
             <td><jbophrase>kerfa silka</jbophrase></td>
             <td>hair silk</td>
-            <td>Kar</td>
+            <td>Karaitic</td>
             <td>velvet</td>
           </tr>
           <tr>
             <td><jbophrase>plise tapla</jbophrase></td>
             <td>apple cake</td>
-            <td>Tur</td>
+            <td>Turkish</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>dadysli junla</jbophrase></td>
             <td>pendulum clock</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td></td>
           </tr>
     </table>
@@ -2533,7 +2496,7 @@
           <tr>
             <td><jbophrase>ckunu tricu</jbophrase></td>
             <td>pine tree</td>
-            <td>Hun,Tur,Hop</td>
+            <td>Hungarian,Turkish,Hopi</td>
             <td></td>
           </tr>
     </table>
@@ -2546,25 +2509,25 @@
           <tr>
             <td><jbophrase>cinfo kerfa</jbophrase></td>
             <td>lion mane</td>
-            <td>Kor,Tur,Hun,Udm,Qab</td>
+            <td>Korean,Turkish,Hungarian,Udmurt,Qabardian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>verba jamfu</jbophrase></td>
             <td>child foot</td>
-            <td>Swe</td>
+            <td>Swedish</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>nixli tuple</jbophrase></td>
             <td>girl leg</td>
-            <td>Swe</td>
+            <td>Swedish</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>cinfo jamfu</jbophrase></td>
             <td>lion foot</td>
-            <td>Que</td>
+            <td>Quechua</td>
             <td></td>
           </tr>
           <tr>
@@ -2582,19 +2545,19 @@
           <tr>
             <td><jbophrase>jmive munje</jbophrase></td>
             <td>living world</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>nobli bakni</jbophrase></td>
             <td>noble cow</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>nolraitru ralju</jbophrase></td>
             <td>king chief</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>emperor</td>
           </tr>
     </table>
@@ -2619,25 +2582,25 @@
           <tr>
             <td><jbophrase>kalselvi'i gapci</jbophrase></td>
             <td>tear gas</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>terbi'a jurme</jbophrase></td>
             <td>disease germ</td>
-            <td>Tur</td>
+            <td>Turkish</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>fenki litki</jbophrase></td>
             <td>crazy liquid</td>
-            <td>Hop</td>
+            <td>Hopi</td>
             <td>whisky</td>
           </tr>
           <tr>
             <td><jbophrase>pinca litki</jbophrase></td>
             <td>urine liquid</td>
-            <td>Hop</td>
+            <td>Hopi</td>
             <td>beer</td>
           </tr>
     </table>
@@ -2653,7 +2616,7 @@
           <tr>
             <td><jbophrase>djacu barna</jbophrase></td>
             <td>water mark</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
     </table>
@@ -2663,25 +2626,25 @@
           <tr>
             <td><jbophrase>taxfu dadgreku</jbophrase></td>
             <td>garment rack</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>tergu'i ti'otci</jbophrase></td>
             <td>lamp shade</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>xirma zdani</jbophrase></td>
             <td>horse house</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>stall</td>
           </tr>
           <tr>
             <td><jbophrase>nuzba tanbo</jbophrase></td>
             <td>news board</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>bulletin board</td>
           </tr>
     </table>
@@ -2698,25 +2661,25 @@
           <tr>
             <td><jbophrase>cpina rokci</jbophrase></td>
             <td>pepper stone</td>
-            <td>Que</td>
+            <td>Quechua</td>
             <td>stone for grinding pepper</td>
           </tr>
           <tr>
             <td><jbophrase>jamfu djacu</jbophrase></td>
             <td>foot water</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>water for washing the feet</td>
           </tr>
           <tr>
             <td><jbophrase>grana mudri</jbophrase></td>
             <td>post wood</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>wood for making a post</td>
           </tr>
           <tr>
             <td><jbophrase>moklu djacu</jbophrase></td>
             <td>mouth water</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td>water for washing the mouth</td>
           </tr>
           <tr>
@@ -2732,67 +2695,67 @@
           <tr>
             <td><jbophrase>moklu djacu</jbophrase></td>
             <td>mouth water</td>
-            <td>Aba,Qab</td>
+            <td>Abazin,Qabardian</td>
             <td>saliva</td>
           </tr>
           <tr>
             <td><jbophrase>ractu mapku</jbophrase></td>
             <td>rabbit hat</td>
-            <td>Rus</td>
+            <td>Russian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>jipci sovda</jbophrase></td>
             <td>chicken egg</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>sikcurnu silka</jbophrase></td>
             <td>silkworm silk</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>mlatu kalci</jbophrase></td>
             <td>cat feces</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>bifce lakse</jbophrase></td>
             <td>bee wax</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>beeswax</td>
           </tr>
           <tr>
             <td><jbophrase>cribe rectu</jbophrase></td>
             <td>bear meat</td>
-            <td>Tur,Kor,Hun,Udm,Aba</td>
+            <td>Turkish,Korean,Hungarian,Udmurt,Abazin</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>solxrula grasu</jbophrase></td>
             <td>sunflower oil</td>
-            <td>Tur,Kor,Hun,Udm,Aba</td>
+            <td>Turkish,Korean,Hungarian,Udmurt,Abazin</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>bifce jisra</jbophrase></td>
             <td>bee juice</td>
-            <td>Hop</td>
+            <td>Hopi</td>
             <td>honey</td>
           </tr>
           <tr>
             <td><jbophrase>tatru litki</jbophrase></td>
             <td>breast liquid</td>
-            <td>Hop</td>
+            <td>Hopi</td>
             <td>milk</td>
           </tr>
           <tr>
             <td><jbophrase>kanla djacu</jbophrase></td>
             <td>eye water</td>
-            <td>Kor</td>
+            <td>Korean</td>
             <td>tear</td>
           </tr>
     </table>
@@ -2808,19 +2771,19 @@
           <tr>
             <td><jbophrase>silna jinto</jbophrase></td>
             <td>salt well</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>kolme terkakpa</jbophrase></td>
             <td>coal mine</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>ctile jinto</jbophrase></td>
             <td>oil well</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
     </table>
@@ -2841,7 +2804,7 @@
           <tr>
             <td><jbophrase>snime nanmu</jbophrase></td>
             <td>snow man</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td></td>
           </tr>
           <tr>
@@ -2853,37 +2816,37 @@
           <tr>
             <td><jbophrase>blaci kanla</jbophrase></td>
             <td>glass eye</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>blaci kanla</jbophrase></td>
             <td>glass eye</td>
-            <td>Que</td>
+            <td>Quechua</td>
             <td>spectacles</td>
           </tr>
           <tr>
             <td><jbophrase>solji sicni</jbophrase></td>
             <td>gold coin</td>
-            <td>Tur</td>
+            <td>Turkish</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>solji junla</jbophrase></td>
             <td>gold watch</td>
-            <td>Tur,Kor,Hun</td>
+            <td>Turkish,Korean,Hungarian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>solji djine</jbophrase></td>
             <td>gold ring</td>
-            <td>Udm,Aba,Que</td>
+            <td>Udmurt,Abazin,Quechua</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>rokci zdani</jbophrase></td>
             <td>stone house</td>
-            <td>Imb</td>
+            <td>Imbabura Quechua</td>
             <td></td>
           </tr>
           <tr>
@@ -2901,25 +2864,25 @@
           <tr>
             <td><jbophrase>solji carce</jbophrase></td>
             <td>gold chariot</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>mudri xarci</jbophrase></td>
             <td>wood weapon</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>wooden weapon</td>
           </tr>
           <tr>
             <td><jbophrase>cmaro'i dargu</jbophrase></td>
             <td>pebble road</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>sudysrasu cutci</jbophrase></td>
             <td>straw shoe</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
     </table>
@@ -2952,25 +2915,25 @@
           <tr>
             <td><jbophrase>tumla spisa</jbophrase></td>
             <td>land piece</td>
-            <td>Tur</td>
+            <td>Turkish</td>
             <td>piece of land</td>
           </tr>
           <tr>
             <td><jbophrase>tcati kabri</jbophrase></td>
             <td>tea cup</td>
-            <td>Kor,Aba</td>
+            <td>Korean,Abazin</td>
             <td>cup of tea</td>
           </tr>
           <tr>
             <td><jbophrase>nanba spisa</jbophrase></td>
             <td>bread piece</td>
-            <td>Kor</td>
+            <td>Korean</td>
             <td>piece of bread</td>
           </tr>
           <tr>
             <td><jbophrase>bukpu spisa</jbophrase></td>
             <td>cloth piece</td>
-            <td>Udm,Aba</td>
+            <td>Udmurt,Abazin</td>
             <td>piece of cloth</td>
           </tr>
           <tr>
@@ -3007,19 +2970,19 @@
           <tr>
             <td><jbophrase>kosta degji</jbophrase></td>
             <td>coat finger</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td>coat sleeve</td>
           </tr>
           <tr>
             <td><jbophrase>denci genja</jbophrase></td>
             <td>tooth root</td>
-            <td>Imb</td>
+            <td>Imbabura Quechua</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>tricu stedu</jbophrase></td>
             <td>tree head</td>
-            <td>Imb</td>
+            <td>Imbabura Quechua</td>
             <td>treetop</td>
           </tr>
     </table>
@@ -3029,7 +2992,7 @@
           <tr>
             <td><jbophrase>silka curnu</jbophrase></td>
             <td>silkworm</td>
-            <td>Tur,Hun,Aba</td>
+            <td>Turkish,Hungarian,Abazin</td>
             <td></td>
           </tr>
     </table>
@@ -3045,31 +3008,31 @@
           <tr>
             <td><jbophrase>ninmu bakni</jbophrase></td>
             <td>woman cattle</td>
-            <td>Imb</td>
+            <td>Imbabura Quechua</td>
             <td>cow</td>
           </tr>
           <tr>
             <td><jbophrase>mamta degji</jbophrase></td>
             <td>mother finger</td>
-            <td>Imb</td>
+            <td>Imbabura Quechua</td>
             <td>thumb</td>
           </tr>
           <tr>
             <td><jbophrase>cifnu degji</jbophrase></td>
             <td>baby finger</td>
-            <td>Imb</td>
+            <td>Imbabura Quechua</td>
             <td>pinky</td>
           </tr>
           <tr>
             <td><jbophrase>pacraistu zdani</jbophrase></td>
             <td>hell house</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>fagri dapma</jbophrase></td>
             <td>fire curse</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>curse destructive as fire</td>
           </tr>
     </table>
@@ -3090,19 +3053,19 @@
           <tr>
             <td><jbophrase>solji kerfa</jbophrase></td>
             <td>gold hair</td>
-            <td>Hun</td>
+            <td>Hungarian</td>
             <td>golden hair</td>
           </tr>
           <tr>
             <td><jbophrase>kanla djacu</jbophrase></td>
             <td>eye water</td>
-            <td>Kar</td>
+            <td>Karaitic</td>
             <td>spring</td>
           </tr>
           <tr>
             <td><jbophrase>bakni rokci</jbophrase></td>
             <td>bull stone</td>
-            <td>Mon</td>
+            <td>Mongolian</td>
             <td>boulder</td>
           </tr>
     </table>
@@ -3117,49 +3080,49 @@
           <tr>
             <td><jbophrase>ckana boxfo</jbophrase></td>
             <td>bed sheet</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>mrostu mojysu'a</jbophrase></td>
             <td>tomb monument</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>tombstone</td>
           </tr>
           <tr>
             <td><jbophrase>jubme tergusni</jbophrase></td>
             <td>table lamp</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>foldi smacu</jbophrase></td>
             <td>field mouse</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>briju ci'ajbu</jbophrase></td>
             <td>office desk</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>rirxe xirma</jbophrase></td>
             <td>river horse</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>hippopotamus</td>
           </tr>
           <tr>
             <td><jbophrase>xamsi gerku</jbophrase></td>
             <td>sea dog</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>seal</td>
           </tr>
           <tr>
             <td><jbophrase>cagyce'u zdani</jbophrase></td>
             <td>village house</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
     </table>
@@ -3177,13 +3140,13 @@
           <tr>
             <td><jbophrase>cidja barja</jbophrase></td>
             <td>food bar</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>restaurant</td>
           </tr>
           <tr>
             <td><jbophrase>cukta barja</jbophrase></td>
             <td>book bar</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>library</td>
           </tr>
     </table>
@@ -3193,19 +3156,19 @@
           <tr>
             <td><jbophrase>kanla velmikce</jbophrase></td>
             <td>eye medicine</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>jgalu grasu</jbophrase></td>
             <td>nail oil</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>nail polish</td>
           </tr>
           <tr>
             <td><jbophrase>denci pesxu</jbophrase></td>
             <td>tooth paste</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
     </table>
@@ -3220,7 +3183,7 @@
           <tr>
             <td><jbophrase>me la pinpan. bolci</jbophrase></td>
             <td>Ping-Pong ball</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
     </table>
@@ -3230,19 +3193,19 @@
           <tr>
             <td><jbophrase>carvi mapku</jbophrase></td>
             <td>rain cap</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>carvi taxfu</jbophrase></td>
             <td>rain garment</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>raincoat</td>
           </tr>
           <tr>
             <td><jbophrase>vindu firgai</jbophrase></td>
             <td>poison mask</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>gas mask</td>
           </tr>
     </table>
@@ -3257,67 +3220,67 @@
           <tr>
             <td><jbophrase>cukta vasru</jbophrase></td>
             <td>book vessel</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>satchel</td>
           </tr>
           <tr>
             <td><jbophrase>vanju kabri</jbophrase></td>
             <td>wine cup</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>spatrkoka lanka</jbophrase></td>
             <td>coca basket</td>
-            <td>Que</td>
+            <td>Quechua</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>rismi dakli</jbophrase></td>
             <td>rice bag</td>
-            <td>Ewe,Chi</td>
+            <td>Ewe,Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>tcati kabri</jbophrase></td>
             <td>tea cup</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>ladru botpi</jbophrase></td>
             <td>milk bottle</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>rismi patxu</jbophrase></td>
             <td>rice pot</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>festi lante</jbophrase></td>
             <td>trash can</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>bifce zdani</jbophrase></td>
             <td>bee house</td>
-            <td>Kor</td>
+            <td>Korean</td>
             <td>beehive</td>
           </tr>
           <tr>
             <td><jbophrase>cladakyxa'i zdani</jbophrase></td>
             <td>sword house</td>
-            <td>Kor</td>
+            <td>Korean</td>
             <td>sheath</td>
           </tr>
           <tr>
             <td><jbophrase>manti zdani</jbophrase></td>
             <td>ant nest</td>
-            <td>Gua</td>
+            <td>Guarani</td>
             <td>anthill</td>
           </tr>
     </table>
@@ -3333,37 +3296,37 @@
           <tr>
             <td><jbophrase>vensa djedi</jbophrase></td>
             <td>spring day</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>crisa citsi</jbophrase></td>
             <td>summer season</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>cerni bumru</jbophrase></td>
             <td>morning fog</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>critu lunra</jbophrase></td>
             <td>autumn moon</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>dunra nicte</jbophrase></td>
             <td>winter night</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>nicte ckule</jbophrase></td>
             <td>night school</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
     </table>
@@ -3373,19 +3336,19 @@
           <tr>
             <td><jbophrase>dikca tergusni</jbophrase></td>
             <td>electric lamp</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>ratni nejni</jbophrase></td>
             <td>atom energy</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>brife molki</jbophrase></td>
             <td>windmill</td>
-            <td>Tur,Kor,Hun,Udm,Aba</td>
+            <td>Turkish,Korean,Hungarian,Udmurt,Abazin</td>
             <td></td>
           </tr>
     </table>
@@ -3400,7 +3363,7 @@
           <tr>
             <td><jbophrase>ladru denci</jbophrase></td>
             <td>milk tooth</td>
-            <td>Tur,Hun,Udm,Qab</td>
+            <td>Turkish,Hungarian,Udmurt,Qabardian</td>
             <td></td>
           </tr>
           <tr>
@@ -3432,31 +3395,31 @@
           <tr>
             <td><jbophrase>cipnrstrigi pacru'i</jbophrase></td>
             <td>owl demon</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>nolraitru prije</jbophrase></td>
             <td>royal sage</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>remna nakni</jbophrase></td>
             <td>human-being male</td>
-            <td>Qab</td>
+            <td>Qabardian</td>
             <td>man</td>
           </tr>
           <tr>
             <td><jbophrase>remna fetsi</jbophrase></td>
             <td>human-being female</td>
-            <td>Qab</td>
+            <td>Qabardian</td>
             <td>woman</td>
           </tr>
           <tr>
             <td><jbophrase>sonci tolvri</jbophrase></td>
             <td>soldier coward</td>
-            <td>Que</td>
+            <td>Quechua</td>
             <td></td>
           </tr>
           <tr>
@@ -3474,25 +3437,25 @@
           <tr>
             <td><jbophrase>solji sicni</jbophrase></td>
             <td>gold coin</td>
-            <td>Tur</td>
+            <td>Turkish</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>solji junla</jbophrase></td>
             <td>gold watch</td>
-            <td>Tur,Kor,Hun</td>
+            <td>Turkish,Korean,Hungarian</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>solji djine</jbophrase></td>
             <td>gold ring</td>
-            <td>Udm,Aba,Que</td>
+            <td>Udmurt,Abazin,Quechua</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>rokci zdani</jbophrase></td>
             <td>stone house</td>
-            <td>Imb</td>
+            <td>Imbabura Quechua</td>
             <td></td>
           </tr>
           <tr>
@@ -3510,19 +3473,19 @@
           <tr>
             <td><jbophrase>solji carce</jbophrase></td>
             <td>gold chariot</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>mudri xarci</jbophrase></td>
             <td>wooden weapon</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td></td>
           </tr>
           <tr>
             <td><jbophrase>zdani tcadu</jbophrase></td>
             <td>home town</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td></td>
           </tr>
     </table>
@@ -3540,43 +3503,43 @@
           <tr>
             <td><jbophrase>nunji'a nunterji'a</jbophrase></td>
             <td>victory defeat</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>victory or defeat</td>
           </tr>
           <tr>
             <td><jbophrase>donri nicte</jbophrase></td>
             <td>day night</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>day and night</td>
           </tr>
           <tr>
             <td><jbophrase>lunra tarci</jbophrase></td>
             <td>moon stars</td>
-            <td>Skt</td>
+            <td>Sanskrit</td>
             <td>moon and stars</td>
           </tr>
           <tr>
             <td><jbophrase>patfu mamta</jbophrase></td>
             <td>father mother</td>
-            <td>Imb,Kaz,Chi</td>
+            <td>Imbabura Quechua,Kazakh,Chinese</td>
             <td>parents</td>
           </tr>
           <tr>
             <td><jbophrase>tuple birka</jbophrase></td>
             <td>leg arm</td>
-            <td>Kaz</td>
+            <td>Kazakh</td>
             <td>extremity</td>
           </tr>
           <tr>
             <td><jbophrase>nuncti nunpinxe</jbophrase></td>
             <td>eating drinking</td>
-            <td>Udm</td>
+            <td>Udmurt</td>
             <td>cuisine</td>
           </tr>
           <tr>
             <td><jbophrase>bersa tixnu</jbophrase></td>
             <td>son daughter</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>children</td>
           </tr>
     </table>
@@ -3594,31 +3557,31 @@
           <tr>
             <td><jbophrase>curnu jalra</jbophrase></td>
             <td>worm beetle</td>
-            <td>Mon</td>
+            <td>Mongolian</td>
             <td>insect</td>
           </tr>
           <tr>
             <td><jbophrase>jalra curnu</jbophrase></td>
             <td>beetle worm</td>
-            <td>Mon</td>
+            <td>Mongolian</td>
             <td>insect</td>
           </tr>
           <tr>
             <td><jbophrase>kabri palta</jbophrase></td>
             <td>cup plate</td>
-            <td>Kaz</td>
+            <td>Kazakh</td>
             <td>crockery</td>
           </tr>
           <tr>
             <td><jbophrase>jipci gunse</jbophrase></td>
             <td>hen goose</td>
-            <td>Qab</td>
+            <td>Qabardian</td>
             <td>housefowl</td>
           </tr>
           <tr>
             <td><jbophrase>xrula tricu</jbophrase></td>
             <td>flower tree</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>vegetation</td>
           </tr>
     </table>
@@ -3628,37 +3591,37 @@
           <tr>
             <td><jbophrase>tumla vacri</jbophrase></td>
             <td>land air</td>
-            <td>Fin</td>
+            <td>Finnish</td>
             <td>world</td>
           </tr>
           <tr>
             <td><jbophrase>moklu stedu</jbophrase></td>
             <td>mouth head</td>
-            <td>Aba</td>
+            <td>Abazin</td>
             <td>face</td>
           </tr>
           <tr>
             <td><jbophrase>sudysrasu cunmi</jbophrase></td>
             <td>hay millet</td>
-            <td>Qab</td>
+            <td>Qabardian</td>
             <td>agriculture</td>
           </tr>
           <tr>
             <td><jbophrase>gugde ciste</jbophrase></td>
             <td>state system</td>
-            <td>Mon</td>
+            <td>Mongolian</td>
             <td>politics</td>
           </tr>
           <tr>
             <td><jbophrase>prenu so'imei</jbophrase></td>
             <td>people multitude</td>
-            <td>Mon</td>
+            <td>Mongolian</td>
             <td>masses</td>
           </tr>
           <tr>
             <td><jbophrase>djacu dertu</jbophrase></td>
             <td>water earth</td>
-            <td>Chi</td>
+            <td>Chinese</td>
             <td>climate</td>
           </tr>
     </table>


### PR DESCRIPTION
5.14 The three letter language abbreviations were probably used to save space, but now that we have actual tables we can safely write the full names of the languages.