### PR TITLE
Remove [ɾ̩]

### DIFF
--- a/chapters/03.xml
+++ b/chapters/03.xml
@@ -207,9 +207,9 @@
           </tr>
           <tr>
             <td><letteral>r</letteral></td>
-            <td><phrase role="IPA">[r]</phrase>, <phrase role="IPA">[ɹ]</phrase>, <phrase role="IPA">[ɾ]</phrase>, <phrase role="IPA">[ʀ]</phrase>, <phrase role="IPA">[r̩]</phrase>, <phrase role="IPA">[ɹ̩]</phrase>, <phrase role="IPA">[ɾ̩]</phrase>, <phrase role="IPA">[ʀ̩]</phrase>
+            <td><phrase role="IPA">[r]</phrase>, <phrase role="IPA">[ɹ]</phrase>, <phrase role="IPA">[ɾ]</phrase>, <phrase role="IPA">[ʀ]</phrase>, <phrase role="IPA">[r̩]</phrase>, <phrase role="IPA">[ɹ̩]</phrase>, <phrase role="IPA">[ʀ̩]</phrase>
             </td>
-            <td><phrase role="X-SAMPA">[r]</phrase>, <phrase role="X-SAMPA">[r\]</phrase>, <phrase role="X-SAMPA">[4]</phrase>, <phrase role="X-SAMPA">[R\]</phrase>, <phrase role="X-SAMPA">[r=]</phrase>, <phrase role="X-SAMPA">[r\=]</phrase>, <phrase role="X-SAMPA">[4=]</phrase>, <phrase role="X-SAMPA">[R\=]</phrase>
+            <td><phrase role="X-SAMPA">[r]</phrase>, <phrase role="X-SAMPA">[r\]</phrase>, <phrase role="X-SAMPA">[4]</phrase>, <phrase role="X-SAMPA">[R\]</phrase>, <phrase role="X-SAMPA">[r=]</phrase>, <phrase role="X-SAMPA">[r\=]</phrase>, <phrase role="X-SAMPA">[R\=]</phrase>
             </td>
             <td>a rhotic sound</td>
           </tr>
@@ -1684,7 +1684,6 @@
       <tr><td>
         <phrase role="IPA">[r̩]</phrase>, 
         <phrase role="IPA">[ɹ̩]</phrase>, 
-        <phrase role="IPA">[ɾ̩]</phrase>, 
         <phrase role="IPA">[ʀ̩]</phrase></td>
       <td>
         Syllabic versions of the above.


### PR DESCRIPTION
For the Lojban phoneme /r/, the IPA symbol for a dental/alveolar voiced apical tap is given with a syllabicity marker below. A tap can't be syllabic, because it is by definition instantaneous.