### PR TITLE
'it is false for some x' => 'it is false that for some x'

### DIFF
--- a/chapters/16.xml
+++ b/chapters/16.xml
@@ -1188,7 +1188,7 @@
     <xref linkend="example-random-id-fpeW"/> by transforming the prenex. To move the negation phrase within the prenex, we must first expand the 
     <valsi>no</valsi> quantifier. Thus 
     <quote>for no x</quote> means the same thing as 
-    <quote>it is false for some x</quote>, and the corresponding Lojban 
+    <quote>it is false that for some x</quote>, and the corresponding Lojban 
     <valsi>noda</valsi> can be replaced by 
     
     <jbophrase>naku su'oda</jbophrase>. Making this substitution, we get:</para>


### PR DESCRIPTION
16.9 It says "for no x" (noda) is the same as "it is false for some x" (naku su'oda). I (mi'e zort) interpret "it is false for some x" as "there is an x such that it is false" (su'oda naku), not "it is false that for some x it is true" (naku su'oda), so it should be changed to "it is false that for some x".
