### PR TITLE
change 'cmalu be le ka canlu' to 'cmalu be le ka se canlu'

### DIFF
--- a/chapters/05.xml
+++ b/chapters/05.xml
@@ -1075,8 +1075,8 @@
         <anchor xml:id="c5e7d3"/>
       </title>
       <interlinear-gloss>
-        <jbo>ti cmalu be le ka canlu</jbo>
-        <gloss>This is-a-small (in-dimension the property-of volume</gloss>
+        <jbo>ti cmalu be le ka se canlu</jbo>
+        <gloss>This is-a-small (in-dimension the property-of [swap--x1--and--x2] volume</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
         <jbo>… bei lo'e ckule be'o</jbo>


### PR DESCRIPTION
The reason is that {ka canlu} most likely means "is the property of being a volume" rather than "is the property of occupying some space". {ka se canlu ma kau} would be implied under this fix.