### PR TITLE
change the gloss for {ba'o}, change the Chnese example with {ba'o}

### DIFF
--- a/chapters/10.xml
+++ b/chapters/10.xml
@@ -1191,7 +1191,7 @@
       <cmavo-entry>
         <cmavo>ba'o</cmavo>
         <selmaho>ZAhO</selmaho>
-        <description>perfective</description>
+        <description>retrospective</description>
       </cmavo-entry>
       <cmavo-entry>
         <cmavo>co'a</cmavo>
@@ -1240,7 +1240,7 @@
         
       </cmavo-entry>
     </cmavo-list>
-    <para role="indent"> <indexterm type="general"><primary>aspect</primary><secondary>natural languages compared with respect to</secondary></indexterm>  <indexterm type="general"><primary>aspect</primary><secondary>expressing</secondary></indexterm>  <indexterm type="general"><primary>resumptive event contour</primary></indexterm>  <indexterm type="general"><primary>pausative event contour</primary></indexterm>  <indexterm type="general"><primary>achievative event contour</primary></indexterm>  <indexterm type="general"><primary>superfective event contour</primary></indexterm>  <indexterm type="general"><primary>completitive event contour</primary></indexterm>  <indexterm type="general"><primary>cessitive event contour</primary></indexterm>  <indexterm type="general"><primary>initiative event contour</primary></indexterm>  <indexterm type="general"><primary>perfective event contour</primary></indexterm>  <indexterm type="general"><primary>continuitive event contour</primary></indexterm>  <indexterm type="general"><primary>inchoative event contour</primary></indexterm> The cmavo of selma'o ZAhO express the Lojban version of what is traditionally called 
+    <para role="indent"> <indexterm type="general"><primary>aspect</primary><secondary>natural languages compared with respect to</secondary></indexterm>  <indexterm type="general"><primary>aspect</primary><secondary>expressing</secondary></indexterm>  <indexterm type="general"><primary>resumptive event contour</primary></indexterm>  <indexterm type="general"><primary>pausative event contour</primary></indexterm>  <indexterm type="general"><primary>achievative event contour</primary></indexterm>  <indexterm type="general"><primary>superfective event contour</primary></indexterm>  <indexterm type="general"><primary>completitive event contour</primary></indexterm>  <indexterm type="general"><primary>cessitive event contour</primary></indexterm>  <indexterm type="general"><primary>initiative event contour</primary></indexterm>  <indexterm type="general"><primary>retrospective event contour</primary></indexterm>  <indexterm type="general"><primary>continuitive event contour</primary></indexterm>  <indexterm type="general"><primary>inchoative event contour</primary></indexterm> The cmavo of selma'o ZAhO express the Lojban version of what is traditionally called 
     <quote>aspect</quote>. This is not a notion well expressed by English tenses, but many languages (including Chinese and Russian among Lojban's six source languages) consider it more important than the specification of mere position in time.</para>
     
     
@@ -1288,13 +1288,13 @@
     </title>
     <interlinear-gloss>
       <jbo>le verba ba'o cadzu le bisli</jbo>
-      <gloss>The child [perfective] walks-on the ice.</gloss>
-      <natlang>The child is finished walking on the ice.</natlang>
+      <gloss>The child [retrospective] walks-on the ice.</gloss>
+      <natlang>The child is no longer walking on the ice.</natlang>
 
     </interlinear-gloss>
   </example>
   <para role="indent"> 
-    <indexterm type="general"><primary>tense direction</primary><secondary>contrasted with event contours in implication of extent</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>contrasted with tense direction in implication of extent</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>implications on scope of event</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>perfective</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>continuitive</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>inchoative</secondary></indexterm> As discussed in 
+    <indexterm type="general"><primary>tense direction</primary><secondary>contrasted with event contours in implication of extent</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>contrasted with tense direction in implication of extent</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>implications on scope of event</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>retrospective</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>continuitive</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>inchoative</secondary></indexterm> As discussed in 
     <xref linkend="section-vagueness"/>, the simple PU cmavo make no assumptions about whether the scope of a past, present, or future event extends into one of the other tenses as well. 
 
     <xref linkend="example-random-id-qdwz"/> through 
@@ -1680,7 +1680,7 @@
       </title>
       <interlinear-gloss>
         <jbo>mi morsi ba'o le nu mi jmive</jbo>
-        <gloss>I am-dead [perfective] the event-of I live.</gloss>
+        <gloss>I am-dead [retrospective] the event-of I live.</gloss>
         <natlang>I die in the aftermath of my living.</natlang>
         
       </interlinear-gloss>
@@ -1716,7 +1716,7 @@
       </title>
       <interlinear-gloss>
         <jbo>mi klama le zarci ba'o le nu mi citka</jbo>
-        <gloss>I go-to the store [perfective] the event-of I eat</gloss>
+        <gloss>I go-to the store [retrospective] the event-of I eat</gloss>
       </interlinear-gloss>
     </example>
     <para role="noindent">would indicate that I go to the store after I am finished eating.</para>
@@ -1735,7 +1735,7 @@
       </interlinear-gloss>
       <interlinear-gloss>
         <jbo>… fe'e ba'o le lalxu</jbo>
-        <gloss>… [space] [perfective] the lake.</gloss>
+        <gloss>… [space] [retrospective] the lake.</gloss>
         <natlang>The boat sailed for too long and beyond the lake.</natlang>
       </interlinear-gloss>
     </example>
@@ -1954,7 +1954,7 @@
       </title>
       <interlinear-gloss>
         <jbo>mi pu klama le ba'o zarci</jbo>
-        <gloss>I [past] go-to the [perfective] market</gloss>
+        <gloss>I [past] go-to the [retrospective] market</gloss>
         <natlang>I went to the former market.</natlang>
         
       </interlinear-gloss>

--- a/chapters/19.xml
+++ b/chapters/19.xml
@@ -169,7 +169,8 @@
         <anchor xml:id="c19e4d2"/>
       </title>
       <itemizedlist>
-        <listitem><para xml:lang="zh"> zhe<superscript>4</superscript> xiao<superscript>1</superscript>xi<superscript>2</superscript> :   wo<superscript>3</superscript> zhi<superscript>1</superscript>dao le </para></listitem>
+        <listitem><para xml:lang="zh">这消息我知道了。</para></listitem>
+        <listitem><para xml:lang="zh">zhe<superscript>4</superscript> xiao<superscript>1</superscript>xi<superscript>2</superscript> :   wo<superscript>3</superscript> zhi<superscript>1</superscript>dao le</para></listitem>
         <listitem><para>this news :   I know [perfective]</para></listitem>
         <listitem><para>As for this news, I knew it.</para></listitem>
         <listitem><para>I've heard this news already.</para></listitem>
@@ -187,8 +188,8 @@
         <indexterm type="example"><primary>news</primary></indexterm>
       </title>
       <interlinear-gloss>
-        <jbo>le nuzba zo'u mi ba'o djuno</jbo>
-        <gloss>The news : I [perfective] know.</gloss>
+        <jbo>le nuzba zo'u mi co'i djuno</jbo>
+        <gloss>The news : I [achievative] know.</gloss>
         
       </interlinear-gloss>
     </example>
@@ -202,7 +203,7 @@
         <indexterm type="example"><primary>news</primary></indexterm>
       </title>
       <interlinear-gloss>
-        <jbo>mi ba'o djuno le nuzba</jbo>
+        <jbo>mi co'i djuno le nuzba</jbo>
         <gloss>I [perfective] know the news.</gloss>
         
       </interlinear-gloss>


### PR DESCRIPTION
There is a strong trend in Lojbanistan to perceive {ba'o} as retrospective (linguistic and well-known terminology), {mo'u} as telicity aspect and {co'i} as perfective aspect (again in linguistic termonology).

Therefore, the gloss "perfective" for {ba'o} is changed to "retrospective" to avoid confusion.

The Chinese particle "le" is closer to {co'i} (perfective) rather than {ba'o}. Therefore, the translation of "zhe xiaoxi wo zhidao le" is changed to le nuzba zo'u mi co'i djuno} replacing {ba'o} with {co'i}.
Also Chinese simplified characters are added for this Chinese example.