### PR TITLE
change "Finally, lujvo involving ``zi'o are also possible, and are fu…

### DIFF
--- a/chapters/07.xml
+++ b/chapters/07.xml
@@ -2117,8 +2117,7 @@
 <indexterm type="general"><primary>beverage</primary><secondary>example</secondary></indexterm>
 
   <indexterm type="general"><primary>zi'o rafsi</primary><secondary>effect of on place structure of lujvo</secondary></indexterm>  <indexterm type="general"><primary>lujvo</primary><secondary>zi'o rafsi effect on place structure of</secondary></indexterm> Finally, lujvo involving 
-    <valsi>zi'o</valsi> are also possible, and are fully discussed in 
-    <xref linkend="chapter-lujvo"/>. In brief, the convention is to use the rafsi for
+    <valsi>zi'o</valsi> are also possible. In brief, the convention is to use the rafsi for
     <valsi>zi'o</valsi> as a prefix immediately followed by the rafsi for the number of the place to be deleted. Thus, if we consider a beverage (something drunk without considering who, if anyone, drinks it) as a 
 
 


### PR DESCRIPTION
ch7 15 Section 15, it says "Finally, lujvo involving ``zi'o are also possible, and are fully discussed in Chapter 12", but nowhere does Chapter 12 mention the word {zi'o}, much less lujvo involving it. Remove the reference to ch12 https://github.com/lojban/cll/pull/318
