### PR TITLE
change the gloss of {pu'o} from 'inchoative' to 'prospective'

### DIFF
--- a/chapters/10.xml
+++ b/chapters/10.xml
@@ -1181,7 +1181,7 @@
       <cmavo-entry>
         <cmavo>pu'o</cmavo>
         <selmaho>ZAhO</selmaho>
-        <description>inchoative</description>
+        <description>prospective</description>
       </cmavo-entry>
       <cmavo-entry>
         <cmavo>ca'o</cmavo>
@@ -1240,7 +1240,7 @@
         
       </cmavo-entry>
     </cmavo-list>
-    <para role="indent"> <indexterm type="general"><primary>aspect</primary><secondary>natural languages compared with respect to</secondary></indexterm>  <indexterm type="general"><primary>aspect</primary><secondary>expressing</secondary></indexterm>  <indexterm type="general"><primary>resumptive event contour</primary></indexterm>  <indexterm type="general"><primary>pausative event contour</primary></indexterm>  <indexterm type="general"><primary>achievative event contour</primary></indexterm>  <indexterm type="general"><primary>superfective event contour</primary></indexterm>  <indexterm type="general"><primary>completitive event contour</primary></indexterm>  <indexterm type="general"><primary>cessitive event contour</primary></indexterm>  <indexterm type="general"><primary>initiative event contour</primary></indexterm>  <indexterm type="general"><primary>perfective event contour</primary></indexterm>  <indexterm type="general"><primary>continuitive event contour</primary></indexterm>  <indexterm type="general"><primary>inchoative event contour</primary></indexterm> The cmavo of selma'o ZAhO express the Lojban version of what is traditionally called 
+    <para role="indent"> <indexterm type="general"><primary>aspect</primary><secondary>natural languages compared with respect to</secondary></indexterm>  <indexterm type="general"><primary>aspect</primary><secondary>expressing</secondary></indexterm>  <indexterm type="general"><primary>resumptive event contour</primary></indexterm>  <indexterm type="general"><primary>pausative event contour</primary></indexterm>  <indexterm type="general"><primary>achievative event contour</primary></indexterm>  <indexterm type="general"><primary>superfective event contour</primary></indexterm>  <indexterm type="general"><primary>completitive event contour</primary></indexterm>  <indexterm type="general"><primary>cessitive event contour</primary></indexterm>  <indexterm type="general"><primary>initiative event contour</primary></indexterm>  <indexterm type="general"><primary>perfective event contour</primary></indexterm>  <indexterm type="general"><primary>continuitive event contour</primary></indexterm>  <indexterm type="general"><primary>prospective event contour</primary></indexterm> The cmavo of selma'o ZAhO express the Lojban version of what is traditionally called 
     <quote>aspect</quote>. This is not a notion well expressed by English tenses, but many languages (including Chinese and Russian among Lojban's six source languages) consider it more important than the specification of mere position in time.</para>
     
     
@@ -1265,7 +1265,7 @@
     </title>
     <interlinear-gloss>
       <jbo>mi pu'o damba</jbo>
-      <gloss>I [inchoative] fight.</gloss>
+      <gloss>I [prospective] fight.</gloss>
       <natlang>I'm on the verge of fighting.</natlang>
     </interlinear-gloss>
   </example>
@@ -1294,7 +1294,7 @@
     </interlinear-gloss>
   </example>
   <para role="indent"> 
-    <indexterm type="general"><primary>tense direction</primary><secondary>contrasted with event contours in implication of extent</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>contrasted with tense direction in implication of extent</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>implications on scope of event</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>perfective</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>continuitive</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>inchoative</secondary></indexterm> As discussed in 
+    <indexterm type="general"><primary>tense direction</primary><secondary>contrasted with event contours in implication of extent</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>contrasted with tense direction in implication of extent</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>implications on scope of event</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>perfective</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>continuitive</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>prospective</secondary></indexterm> As discussed in 
     <xref linkend="section-vagueness"/>, the simple PU cmavo make no assumptions about whether the scope of a past, present, or future event extends into one of the other tenses as well. 
 
     <xref linkend="example-random-id-qdwz"/> through 
@@ -1310,12 +1310,12 @@
     <valsi>pu</valsi>, is referring to a future event; whereas 
 
     <valsi>ba'o</valsi>, connected with 
-    <valsi>ba</valsi>, is referring to a past event. This is the natural result of the event-centered view of ZAhO cmavo. The inchoative, or 
+    <valsi>ba</valsi>, is referring to a past event. This is the natural result of the event-centered view of ZAhO cmavo. The prospective, or 
 
     <valsi>pu'o</valsi>, part of an event, is in the 
     <quote>pastward</quote> portion of that event, when seen from the perspective of the event itself. It is only by inference that we suppose that 
 
-    <xref linkend="example-random-id-qdwz"/> refers to the speaker's future: in fact, no PU tense is given, so the inchoative part of the event need not be coincident with the speaker's present: 
+    <xref linkend="example-random-id-qdwz"/> refers to the speaker's future: in fact, no PU tense is given, so the prospective part of the event need not be coincident with the speaker's present: 
     <valsi>pu'o</valsi> is not necessarily, though in fact often is, the same as 
     <jbophrase>ca pu'o</jbophrase>.</para>
     <para> <indexterm type="general"><primary>event contours</primary><secondary>cessative</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>initiative</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>division of the event into</secondary></indexterm>  <indexterm type="general"><primary>event contours</primary><secondary>points associated with</secondary></indexterm> The cmavo in 
@@ -1706,7 +1706,7 @@
       </title>
       <interlinear-gloss>
         <jbo>mi klama le zarci pu'o le nu mi citka</jbo>
-        <gloss>I go-to the store [inchoative] the event-of I eat</gloss>
+        <gloss>I go-to the store [prospective] the event-of I eat</gloss>
       </interlinear-gloss>
     </example>
     <para role="noindent">which indicates that before my eating begins, I go to the store, whereas</para>
@@ -3488,7 +3488,7 @@
       </title>
       <interlinear-gloss>
         <jbo>pu'o</jbo>
-        <gloss>[inchoative]</gloss>
+        <gloss>[prospective]</gloss>
         <natlang>He hasn't yet done so.</natlang>
       </interlinear-gloss>
     </example>

--- a/chapters/20.xml
+++ b/chapters/20.xml
@@ -1316,7 +1316,7 @@
     <para>A tense modifier specifying the contour of an event (e.g. beginning, ending, continuing).</para>
     <interlinear-gloss>
       <jbo>mi pu'o damba</jbo>
-      <gloss>I [inchoative] fight.</gloss>
+      <gloss>I [prospective] fight.</gloss>
       <natlang>I'm on the verge of fighting.</natlang>
     </interlinear-gloss>
     <bridgehead>

--- a/chapters/21.xml
+++ b/chapters/21.xml
@@ -430,7 +430,7 @@
 
 %token 
 <anchor xml:id="y621"/>
-<anchor xreflabel="YACC rule #621" xml:id="cll_yacc-621"/> ZAhO_621         /* event properties &ndash; inchoative, etc. */
+<anchor xreflabel="YACC rule #621" xml:id="cll_yacc-621"/> ZAhO_621         /* event properties &ndash; prospective, etc. */
 %token 
 <anchor xml:id="y622"/>
 <anchor xreflabel="YACC rule #622" xml:id="cll_yacc-622"/> ZEhA_622         /* time interval size tense */


### PR DESCRIPTION
"inchoative" in linguistics is rather {co'a} than {pu'o}. {pu'o} is definitely "prospective"