### PR TITLE
partial downgrade according to vetoes for CLL 1.2

### DIFF
--- a/chapters/09.xml
+++ b/chapters/09.xml
@@ -1982,7 +1982,7 @@
     <xref linkend="example-random-id-qMSb"/>, because 
     <valsi>ke</valsi>&hellip;<valsi>ke'e</valsi> cannot extend across more than one sentence. It would also be possible to change the 
     <jbophrase>.ijeseri'abo</jbophrase> to 
-    <jbophrase>.ije ri'a</jbophrase>, which would show that the 
+    <jbophrase>.ije seri'a</jbophrase>, which would show that the 
     <valsi>tu'e</valsi>&hellip;<valsi>tu'u</valsi> portion was an effect, but would not pin down the 
     <jbophrase>mi bevri le dakli</jbophrase> portion as the cause. It is legal for a modal (or a tense; see 
     <xref linkend="chapter-tenses"/>) to modify the whole of a 

--- a/chapters/11.xml
+++ b/chapters/11.xml
@@ -498,7 +498,7 @@
         <anchor xml:id="c11e4d4"/>
       </title>
       <interlinear-gloss>
-        <jbo>le du'u do xunre [kei] cu cnino mi</jbo>
+        <jbo>le ka do xunre [kei] cu cnino mi</jbo>
         <gloss>The proposition-of you being-red -- -- is-new to--me.</gloss>
         <natlang>Your redness is new to me.</natlang>
       </interlinear-gloss>


### PR DESCRIPTION
```
Curtis W. Fraŋks: 
I hereby veto:
• "Chapter 9: JC will think about it
Section 11, description of the meaning of ".ije seri'a tu'e" contradicts the explanation of Example 9.9, which would suggest ".ije ri'a tu'e"." <-- (I think that "se" is fine. I am not sure what Example 9.9 is, because the labelling does not align properly, but we may need to edit that instead)
• "Chapter 11: JC OK (obviously)
Section 4: The use of ka in Example 4.4 (page 259) is erroneous; it should be du'u. --John Cowan" <-- (I think that "ka" is fine and "du'u" is erroneous)
```
link: https://mw.lojban.org/papri/CLL_1.2._Technical