### PR TITLE
remove "to movie" indexterm

### DIFF
--- a/chapters/09.xml
+++ b/chapters/09.xml
@@ -454,9 +454,10 @@
     <valsi>fe</valsi>, and 
     <jbophrase>le karce</jbophrase> skips over the already-occupied x3 and x4 places to land in the x5 place.</para>
     <para> <indexterm type="general"><primary>FA selma'o</primary><secondary>avoidance of complex usage of</secondary></indexterm> Such a convoluted use of tags should probably be avoided except when trying for a literal translation of some English (or other natural-language) sentence; the rules stated here are merely given so that some standard interpretation is possible.</para>
-    <para> <indexterm type="general"><primary>multiple sumti in one place</primary><secondary>meaning</secondary></indexterm>  <indexterm type="general"><primary>sumti</primary><secondary>multiple in one place with FA</secondary></indexterm>  <indexterm type="general"><primary>FA selma'o</primary><secondary>for putting more than one sumti in a single place</secondary></indexterm> It is grammatically permitted to tag more than one sumti with the same FA cmavo. The effect is that of making more than one claim:</para>
+    <para> <indexterm type="general"><primary>sumti in one place</primary><secondary>multiple ones</secondary></indexterm>  <indexterm type="general"><primary>sumti</primary><secondary>multiple in one place with FA</secondary></indexterm>  <indexterm type="general"><primary>FA selma'o</primary><secondary>for putting more than one sumti in a single place</secondary></indexterm> It is grammatically permitted to tag more than one sumti with the same FA cmavo. The effect is that of making more than one claim:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-N1aE">
       <title>
+        <indexterm type="example"><primary>movie</primary><secondary>example of going to</secondary><tertiary>office: example</tertiary></indexterm>
         <anchor xml:id="c9e3d9"/>
       </title>
       <interlinear-gloss>

--- a/chapters/09.xml
+++ b/chapters/09.xml
@@ -457,7 +457,6 @@
     <para> <indexterm type="general"><primary>multiple sumti in one place</primary><secondary>meaning</secondary></indexterm>  <indexterm type="general"><primary>sumti</primary><secondary>multiple in one place with FA</secondary></indexterm>  <indexterm type="general"><primary>FA selma'o</primary><secondary>for putting more than one sumti in a single place</secondary></indexterm> It is grammatically permitted to tag more than one sumti with the same FA cmavo. The effect is that of making more than one claim:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-N1aE">
       <title>
-     <indexterm type="example"><primary>to movie</primary><secondary>house</secondary><tertiary>office: example</tertiary></indexterm>
         <anchor xml:id="c9e3d9"/>
       </title>
       <interlinear-gloss>


### PR DESCRIPTION
1. "to movie - house - office: example" is weird in glossary and probably not useful
2. the indexterm "multiple sumti in one place - meaning" changed to "sumti in one place - multiple ones"