### PR TITLE
hours - minutes - seconds

### DIFF
--- a/chapters/18.xml
+++ b/chapters/18.xml
@@ -1798,7 +1798,9 @@
     <example role="interlinear-gloss-example" xml:id="example-random-id-17HR">
       <title>
         <anchor xml:id="c18e10d5"/>
-        <indexterm type="example"><primary>hours</primary><secondary>minutes</secondary><tertiary>seconds: example</tertiary></indexterm>  
+        <indexterm type="example"><primary>hours</primary><secondary>example of timestamp</secondary></indexterm>  
+        <indexterm type="example"><primary>minutes</primary><secondary>example of timestamp</secondary></indexterm>  
+        <indexterm type="example"><primary>seconds</primary><secondary>example of timestamp</secondary></indexterm>  
       </title>
       <interlinear-gloss>
         <jbo>ci pi'e rere pi'e vono</jbo>


### PR DESCRIPTION
three-level indexterm is weird in glossary. 3 indexterms for hours, minutes, seconds separately are added.