### PR TITLE
#370 (styling not addressed)

### DIFF
--- a/scripts/generate_glossary.rb
+++ b/scripts/generate_glossary.rb
@@ -99,6 +99,7 @@ definitions.  These definitions are here simply as a quick reference.
       end
 
       definition=nil
+      examples=[]
       if opts[:testing]
         definition="placeholder definition"
       else
@@ -131,14 +132,23 @@ definitions.  These definitions are here simply as a quick reference.
           definition=nil
           $stderr.puts %Q{NO JBOVLASTE DEFINITION FOR "#{word}" FOUND!}
         end
+        jbovlaste_tree.xpath(%Q{//valsi[@word="#{word}"]}).xpath(".//examples/example").each do |example|
+          source = Nokogiri::XML.parse(example.to_s).xpath("//source").text.strip
+          translation = Nokogiri::XML.parse(example.to_s).xpath(%Q{//target[@language="English"]/translation}).text.strip
+          examples.push("<para>#{source} — #{translation}</para>")
+        end
       end
-
+      if examples.length() > 0
+        examples = "\n  #{examples.join("\n  ")}"
+      else
+        examples=""
+      end
       if definition
         gfh.puts %Q{
 <glossentry xml:id="valsi-#{slug}">
 <glossterm>#{word}</glossterm>
 <glossdef>
-  <para>#{definition}</para>
+  <para>#{definition}</para>#{examples}
 </glossdef>
 </glossentry>
         }


### PR DESCRIPTION
partial (css not adressed) solution to https://github.com/lojban/cll/issues/370
A dictionary with only {coi} and {mi}
results in something like

```
<glossdiv><title>C</title>

<glossentry xml:id="valsi-coi">
<glossterm>coi</glossterm>
<glossdef>
  <para>vocative: greetings/hello.</para>
  <para>coi .djan. — Hello, John.</para>
  <para>coi .djan. — Hello, John.</para>
</glossdef>
</glossentry>

</glossdiv>
<glossdiv><title>M</title>

<glossentry xml:id="valsi-mi">
<glossterm>mi</glossterm>
<glossdef>
  <para>pro-sumti: me/we the speaker(s)/author(s); identified by self-vocative.</para>
</glossdef>
</glossentry>



</glossdiv>
```

# Testing

Please use a jbovlaste.xml file with <examples> nodes as in https://github.com/lojban/cll/issues/370