### PR TITLE
Cmevla terminology

### DIFF
--- a/chapters/02.xml
+++ b/chapters/02.xml
@@ -1362,8 +1362,8 @@
     <valsi>coi</valsi> means 
     <quote>hello</quote> and 
     <valsi>co'o</valsi> means 
-    <quote>good-bye</quote>. Either word may stand alone, they may follow one another, or either may be followed by a pause and a name. (Vocative phrases with 
-    <valsi>doi</valsi> do not need a pause before the name.)</para>
+    <quote>good-bye</quote>. Either word may stand alone, they may follow one another, or either may be followed by a pause and a cmevla. (Vocative phrases with 
+    <valsi>doi</valsi> do not need a pause before a cmevla.)</para>
     <example xml:id="example-random-id-qIWX" role="interlinear-gloss-example">
       <title>
         <anchor xml:id="c2e14d2"/>

--- a/chapters/03.xml
+++ b/chapters/03.xml
@@ -379,7 +379,7 @@
       </pronunciation>
     </example>
     <para role="noindent">which is technically a different Lojban name. Since the intent with Lojbanized names is to allow them to be pronounced more like their native counterparts, the comma is allowed to represent vowel glides or some non-Lojbanic sound. Such an exception affects only spelling accuracy and the ability of a reader to replicate the desired pronunciation exactly; it will not affect the recognition of word boundaries.</para>
-    <para> <indexterm type="general"><primary>apostrophe</primary><secondary>as preferable over comma in names</secondary></indexterm> Still, it is better if Lojbanized names are always distinct. Therefore, the apostrophe is preferred in regular Lojbanized names that are not attempting to simulate a non-Lojban pronunciation perfectly. (Perfection, in any event, is not really achievable, because some sounds simply lack reasonable Lojbanic counterparts.)</para>
+    <para> <indexterm type="general"><primary>apostrophe</primary><secondary>as preferable over comma in Lojbanized names</secondary></indexterm> Still, it is better if Lojbanized names are always distinct. Therefore, the apostrophe is preferred in regular Lojbanized names that are not attempting to simulate a non-Lojban pronunciation perfectly. (Perfection, in any event, is not really achievable, because some sounds simply lack reasonable Lojbanic counterparts.)</para>
     <para>If apostrophes were used instead of commas in 
     <xref linkend="example-random-id-k2b9"/>, it would appear as:</para>
     <example role="pronunciation-example" xml:id="example-random-id-k2bc">
@@ -518,7 +518,7 @@
     <phrase role="IPA">[l]</phrase>, 
     <phrase role="IPA">[m]</phrase>, 
     <phrase role="IPA">[n]</phrase>, and 
-    <phrase role="IPA">[r]</phrase> respectively. They normally have only a limited distribution, appearing in Lojban names and borrowings, although in principle any 
+    <phrase role="IPA">[r]</phrase> respectively. They normally have only a limited distribution, appearing in Lojbanized names and borrowings, although in principle any 
     
     <letteral>l</letteral>, 
     <letteral>m</letteral>, 
@@ -1004,7 +1004,7 @@
         <morphology>nts</morphology> are forbidden.</para>
       </listitem>
     </orderedlist>
-    <para> <indexterm type="general"><primary>consonant clusters</primary><secondary>more than three consonants in</secondary></indexterm> Lojbanized names can begin or end with any permissible consonant pair, not just the 48 initial consonant pairs listed above, and can have consonant triples in any location, as long as the pairs making up those triples are permissible. In addition, names can contain consonant clusters with more than three consonants, again requiring that each pair within the cluster is valid.</para>
+    <para> <indexterm type="general"><primary>consonant clusters</primary><secondary>more than three consonants in</secondary></indexterm> Lojbanized names can begin or end with any permissible consonant pair, not just the 48 initial consonant pairs listed above, and can have consonant triples in any location, as long as the pairs making up those triples are permissible. In addition, Lojbanized names can contain consonant clusters with more than three consonants, again requiring that each pair within the cluster is valid.</para>
     
     
     
@@ -1150,7 +1150,7 @@
     
     <quote>vowels</quote> for the purposes of this section.) Syllabication rules determine which of the consonants separating two vowels belong to the preceding vowel and which to the following vowel. These rules are conventional only; the phonetic facts of the matter about how utterances are syllabified in any language are always very complex.</para>
     <para> <indexterm type="general"><primary>syllabication</primary><secondary>rules for</secondary></indexterm> A single consonant always belongs to the following vowel. A consonant pair is normally divided between the two vowels; however, if the pair constitute a valid initial consonant pair, they are normally both assigned to the following vowel. A consonant triple is divided between the first and second consonants. Apostrophes and commas, of course, also represent syllable breaks. Syllabic consonants usually appear alone in their syllables.</para>
-    <para> <indexterm type="general"><primary>syllabication</primary><secondary>and names</secondary></indexterm> It is permissible to vary from these rules in Lojbanized names. For example, there are no definitive rules for the syllabication of names with consonant clusters longer than three consonants. The comma is used to indicate variant syllabication or to explicitly mark normal syllabication.</para>
+    <para> <indexterm type="general"><primary>syllabication</primary><secondary>and names</secondary></indexterm> It is permissible to vary from these rules in Lojbanized names. For example, there are no definitive rules for the syllabication of Lojbanized names with consonant clusters longer than three consonants. The comma is used to indicate variant syllabication or to explicitly mark normal syllabication.</para>
     
     
     
@@ -1228,8 +1228,8 @@
     <phrase role="IPA">[ɪ]</phrase>, are not counted.</para>
     <para> <indexterm type="general"><primary>stress</primary><secondary>levels of</secondary></indexterm> There are actually three levels of stress &ndash; primary, secondary, and weak. Weak stress is the lowest level, so it really means no stress at all. Weak stress is required for syllables containing 
     <letteral>y</letteral>, a syllabic consonant, or a buffer vowel.</para>
-    <para> <indexterm type="general"><primary>names</primary><secondary>stress on</secondary></indexterm>  <indexterm type="general"><primary>brivla</primary><secondary>stress on</secondary></indexterm>  <indexterm type="general"><primary>cmavo</primary><secondary>stress on</secondary></indexterm>  <indexterm type="general"><primary>stress</primary><secondary>primary</secondary></indexterm> Primary stress is required on the penultimate syllable of Lojban content words (called 
-    <valsi>brivla</valsi>). Lojbanized names may be stressed on any syllable, but if a syllable other than the penultimate is stressed, the syllable (or at least its vowel) must be capitalized in writing. Lojban structural words (called 
+    <para> <indexterm type="general"><primary>cmevla</primary><secondary>stress on</secondary></indexterm>  <indexterm type="general"><primary>brivla</primary><secondary>stress on</secondary></indexterm>  <indexterm type="general"><primary>cmavo</primary><secondary>stress on</secondary></indexterm>  <indexterm type="general"><primary>stress</primary><secondary>primary</secondary></indexterm> Primary stress is required on the penultimate syllable of Lojban content words (called 
+    <valsi>brivla</valsi>). Lojbanized names (called <valsi>cmevla</valsi>) may be stressed on any syllable, but if a syllable other than the penultimate is stressed, the syllable (or at least its vowel) must be capitalized in writing. Lojban structural words (called 
     <valsi>cmavo</valsi>) may be stressed on any syllable or none at all. However, primary stress may not be used in a syllable just preceding a brivla, unless a pause divides them; otherwise, the two words may run together.</para>
     <para> <indexterm type="general"><primary>stress</primary><secondary>secondary</secondary></indexterm> Secondary stress is the optional and non-distinctive emphasis used for other syllables besides those required to have either weak or primary stress. There are few rules governing secondary stress, which typically will follow a speaker's native language habits or preferences. Secondary stress can be used for contrast, or for emphasis of a point. Secondary stress can be emphasized at any level up to primary stress, although the speaker must not allow a false primary stress in brivla, since errors in word resolution could result.</para>
     <para>  The following are Lojban words with stress explicitly shown:</para>
@@ -1930,7 +1930,7 @@
           <diphthong>i,a</diphthong> through 
           <diphthong>i,u</diphthong> and 
           <diphthong>u,a</diphthong> through 
-          <diphthong>u,u</diphthong> in names, fu'ivla, and attitudinal cmavo.
+          <diphthong>u,u</diphthong> in cmevla, fu'ivla, and attitudinal cmavo.
         </para>
       </listitem>
       <listitem>

--- a/chapters/04.xml
+++ b/chapters/04.xml
@@ -235,7 +235,7 @@
         <para> <indexterm type="general"><primary>C/CC string</primary><secondary>as a symbol for a consonant triple</secondary></indexterm> C/CC represents a consonant triple. The first two consonants must constitute a permissible consonant pair; the last two consonants must constitute a permissible initial consonant pair.</para>
       </listitem>
     </orderedlist>
-    <para> <indexterm type="general"><primary>brivla</primary><secondary>as one of the 3 basic word classes</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>as one of the 3 basic word classes</secondary></indexterm>  <indexterm type="general"><primary>cmavo</primary><secondary>as one of the 3 basic word classes</secondary></indexterm>  <indexterm type="general"><primary>parts of speech</primary></indexterm>  <indexterm type="general"><primary>word classes</primary></indexterm> Lojban has three basic word classes &ndash; parts of speech &ndash; in contrast to the eight that are traditional in English. These three classes are called cmavo, brivla, and cmene. Each of these classes has uniquely identifying properties &ndash; an arrangement of letters that allows the word to be uniquely and unambiguously recognized as a separate word in a string of Lojban, upon either reading or hearing, and as belonging to a specific word-class.</para>
+    <para> <indexterm type="general"><primary>brivla</primary><secondary>as one of the 3 basic word classes</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>as one of the 3 basic word classes</secondary></indexterm>  <indexterm type="general"><primary>cmavo</primary><secondary>as one of the 3 basic word classes</secondary></indexterm>  <indexterm type="general"><primary>parts of speech</primary></indexterm>  <indexterm type="general"><primary>word classes</primary></indexterm> Lojban has three basic word classes &ndash; parts of speech &ndash; in contrast to the eight that are traditional in English. These three classes are called cmavo, brivla, and cmevla. Each of these classes has uniquely identifying properties &ndash; an arrangement of letters that allows the word to be uniquely and unambiguously recognized as a separate word in a string of Lojban, upon either reading or hearing, and as belonging to a specific word-class.</para>
     
     
     <para>They are also functionally different: cmavo are the structure words, corresponding to English words like 
@@ -247,7 +247,7 @@
     <quote>come</quote>, 
     <quote>red</quote>, 
     <quote>doctor</quote>, and 
-    <quote>freely</quote>; cmene are proper names, corresponding to English 
+    <quote>freely</quote>; cmevla are proper names, corresponding to English 
     <quote>James</quote>, 
     <quote>Afghanistan</quote>, and 
     <quote>Pope John Paul II</quote>.</para>
@@ -454,7 +454,7 @@
     
     
     
-    <para> <indexterm type="general"><primary>subtypes of words</primary></indexterm>  <indexterm type="general"><primary>types and subtypes of words</primary></indexterm> Every brivla belongs to one of three major subtypes. These subtypes are defined by the form, or morphology, of the word &ndash; all words of a particular structure can be assigned by sight or sound to a particular type (cmavo, brivla, or cmene) and subtype. Knowing the type and subtype then gives you, the reader or listener, significant clues to the meaning and the origin of the word, even if you have never heard the word before.</para>
+    <para> <indexterm type="general"><primary>subtypes of words</primary></indexterm>  <indexterm type="general"><primary>types and subtypes of words</primary></indexterm> Every brivla belongs to one of three major subtypes. These subtypes are defined by the form, or morphology, of the word &ndash; all words of a particular structure can be assigned by sight or sound to a particular type (cmavo, brivla, or cmevla) and subtype. Knowing the type and subtype then gives you, the reader or listener, significant clues to the meaning and the origin of the word, even if you have never heard the word before.</para>
     
     <para> <indexterm type="general"><primary>flexible vocabulary</primary></indexterm> The same principle allows you, when speaking or writing, to invent new brivla for new concepts 
     <quote>on the fly</quote>; yet it offers people that you are trying to communicate with a good chance to figure out your meaning. In this way, Lojban has a flexible vocabulary which can be expanded indefinitely.</para>
@@ -473,9 +473,9 @@
         <para>always are stressed on the next-to-the-last (penultimate) syllable; this implies that they have two or more syllables.</para>
       </listitem>
     </orderedlist>
-    <para> <indexterm type="general"><primary>cmene form</primary><secondary>contrasted with brivla form</secondary></indexterm>  <indexterm type="general"><primary>cmavo form</primary><secondary>contrasted with brivla form</secondary></indexterm>  <indexterm type="general"><primary>brivla form</primary><secondary>contrasted with cmene form</secondary></indexterm>  <indexterm type="general"><primary>brivla form</primary><secondary>contrasted with cmavo form</secondary></indexterm>  <indexterm type="general"><primary>brivla</primary><secondary>recognition of</secondary></indexterm> The presence of a consonant pair distinguishes brivla from cmavo and their compounds. The final vowel distinguishes brivla from cmene, which always end in a consonant. Thus 
+    <para> <indexterm type="general"><primary>cmevla form</primary><secondary>contrasted with brivla form</secondary></indexterm>  <indexterm type="general"><primary>cmavo form</primary><secondary>contrasted with brivla form</secondary></indexterm>  <indexterm type="general"><primary>brivla form</primary><secondary>contrasted with cmevla form</secondary></indexterm>  <indexterm type="general"><primary>brivla form</primary><secondary>contrasted with cmavo form</secondary></indexterm>  <indexterm type="general"><primary>brivla</primary><secondary>recognition of</secondary></indexterm> The presence of a consonant pair distinguishes brivla from cmavo and their compounds. The final vowel distinguishes brivla from cmevla, which always end in a consonant. Thus 
     <jbophrase>da'amei</jbophrase> must be a compound cmavo because it lacks a consonant pair; 
-    <valsi>lojban.</valsi> must be a name because it lacks a final vowel.</para>
+    <valsi>lojban.</valsi> must be a cmevla because it lacks a final vowel.</para>
     <para> <indexterm type="general"><primary>consonant pairs</primary><secondary>letter y within</secondary></indexterm>  <indexterm type="general"><primary>y</primary><secondary>letter</secondary><tertiary>between letters of consonant pair</tertiary></indexterm>  <indexterm type="general"><primary>consonant pairs</primary><secondary>in brivla</secondary></indexterm>  <indexterm type="general"><primary>brivla</primary><secondary>consonant pairs in</secondary></indexterm> Thus, 
     <valsi valid='maybe'>bisycla</valsi> has the consonant pair 
     <morphology>sc</morphology> in the first five non- 
@@ -1085,10 +1085,10 @@ There is also a different way of building lujvo, or rather phrases which are gra
         <jbo>bridi zei valsi</jbo>
       </lujvo-making>
     </example>
-    <para role="noindent"> <indexterm type="general"><primary>cmavo without rafsi</primary><secondary>method of including in lujvo</secondary></indexterm>  <indexterm type="general"><primary>fu'ivla</primary><secondary>method of including in lujvo</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>method of including in lujvo</secondary></indexterm>  <indexterm type="general"><primary>rafsi</primary><secondary>lack of</secondary><tertiary>effect on forming lujvo</tertiary></indexterm>  <indexterm type="general"><primary>lujvo</primary><secondary>from cmavo with no rafsi</secondary></indexterm> is the exact equivalent of 
+    <para role="noindent"> <indexterm type="general"><primary>cmavo without rafsi</primary><secondary>method of including in lujvo</secondary></indexterm>  <indexterm type="general"><primary>fu'ivla</primary><secondary>method of including in lujvo</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>method of including in lujvo</secondary></indexterm>  <indexterm type="general"><primary>rafsi</primary><secondary>lack of</secondary><tertiary>effect on forming lujvo</tertiary></indexterm>  <indexterm type="general"><primary>lujvo</primary><secondary>from cmavo with no rafsi</secondary></indexterm> is the exact equivalent of 
     <valsi>brivla</valsi> (but not necessarily the same as the underlying tanru 
     <jbophrase>bridi valsi</jbophrase>, which could have other meanings.) Using 
-    <valsi>zei</valsi> is the only way to get a cmavo lacking a rafsi, a cmene, or a fu'ivla into a lujvo:</para>
+    <valsi>zei</valsi> is the only way to get a cmavo lacking a rafsi, a cmevla, or a fu'ivla into a lujvo:</para>
     <example xml:id="example-random-id-qJe1" role="lujvo-example">
       <title>
         
@@ -1205,7 +1205,7 @@ There is also a different way of building lujvo, or rather phrases which are gra
     <quote>x1 is a quantity of spaghetti</quote>.</para>
     
     <para> <indexterm type="general"><primary>borrowings</primary><secondary>Stage 2</secondary></indexterm>  <indexterm type="general"><primary>borrowings</primary><secondary>using lojbanized name</secondary></indexterm> Stage 2 involves changing the foreign name to a Lojbanized name, as explained in 
-    <xref linkend="section-cmene"/>:</para>
+    <xref linkend="section-cmevla"/>:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-zijY">
       <title>
         <anchor xml:id="c4e7d2"/>
@@ -1558,12 +1558,12 @@ The prefix method would render the mathematical concept as
     
     <quote>Dine'e</quote>.</para>
   </section>
-  <section xml:id="section-cmene">
-    <title><anchor xml:id="c4s8"/>cmene</title>
-    <para> <indexterm type="general"><primary>names in Lojban (see also cmene)</primary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>definition</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>purpose of</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>purpose of</secondary></indexterm> Lojbanized names, called 
-    <valsi>cmene</valsi>, are very much like their counterparts in other languages. They are labels applied to things (or people) to stand for them in descriptions or in direct address. They may convey meaning in themselves, but do not necessarily do so.</para>
+  <section xml:id="section-cmevla">
+    <title><anchor xml:id="c4s8"/>cmevla</title>
+    <para> <indexterm type="general"><primary>names in Lojban (see also cmevla)</primary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>definition</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>purpose of</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>purpose of</secondary></indexterm> Lojbanized names, called 
+    <valsi>cmevla</valsi>, are very much like their counterparts in other languages. They are labels applied to things (or people) to stand for them in descriptions or in direct address. They may convey meaning in themselves, but do not necessarily do so.</para>
     
-    <para> <indexterm type="general"><primary>names</primary><secondary>rationale for lojbanizing</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>rationale for lojbanizing</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>and analyzability of speech stream</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>examples of</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>examples of</secondary></indexterm> Because names are often highly personal and individual, Lojban attempts to allow native language names to be used with a minimum of modification. The requirement that the Lojban speech stream be unambiguously analyzable, however, means that most names must be modified somewhat when they are Lojbanized. Here are a few examples of English names and possible Lojban equivalents:</para>
+    <para> <indexterm type="general"><primary>names</primary><secondary>rationale for lojbanizing</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>rationale for lojbanizing</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>and analyzability of speech stream</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>examples of</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>examples of</secondary></indexterm> Because names are often highly personal and individual, Lojban attempts to allow native language names to be used with a minimum of modification. The requirement that the Lojban speech stream be unambiguously analyzable, however, means that most names must be modified somewhat when they are Lojbanized. Here are a few examples of English names and possible Lojban equivalents:</para>
     <example xml:id="example-random-id-qjhN" role="lojbanization-example">
       <title>
         
@@ -1688,7 +1688,7 @@ The prefix method would render the mathematical concept as
         
       </lojbanization>
     </example>
-    <para role="indent"><indexterm type="general"><primary>names</primary><secondary>unusual stress in</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>unusual stress in</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>stress in</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>stress in</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>rules for formation</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>rules for formation</secondary></indexterm> Names may have almost any form, but always end in a consonant, and are followed by a pause. They are penultimately stressed, unless unusual stress is marked with capitalization. A name may have multiple parts, each ending with a consonant and pause, or the parts may be combined into a single word with no pause. For example,</para>
+    <para role="indent"><indexterm type="general"><primary>names</primary><secondary>unusual stress in</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>unusual stress in</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>stress in</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>stress in</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>rules for formation</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>rules for formation</secondary></indexterm> Cmevla may have almost any form, but always end in a consonant, and are followed by a pause. They are penultimately stressed, unless unusual stress is marked with capitalization. A cmevla may have multiple parts, each ending with a consonant and pause, or the parts may be combined into a single word with no pause. For example,</para>
     
     <example role="lojbanization-example" xml:id="example-random-id-43uP">
       <title>
@@ -1714,7 +1714,7 @@ The prefix method would render the mathematical concept as
     <para role="noindent">are both valid Lojbanizations of 
     <quote>John Brown</quote>.</para>
     
-    <para> <indexterm type="general"><primary>names</primary><secondary>authority for</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>authority for</secondary></indexterm> The final arbiter of the correct form of a name is the person doing the naming, although most cultures grant people the right to determine how they want their own name to be spelled and pronounced. The English name 
+    <para> <indexterm type="general"><primary>names</primary><secondary>authority for</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>authority for</secondary></indexterm> The final arbiter of the correct form of a name is the person doing the naming, although most cultures grant people the right to determine how they want their own name to be spelled and pronounced. The English name 
     <quote>Mary</quote> can thus be Lojbanized as 
     <cmevla>meris.</cmevla>, 
     <cmevla>maris.</cmevla>, 
@@ -1722,10 +1722,10 @@ The prefix method would render the mathematical concept as
     <cmevla>merix.</cmevla>, or even 
     <cmevla>marys.</cmevla>. The last alternative is not pronounced much like its English equivalent, but may be desirable to someone who values spelling over pronunciation. The final consonant need not be an 
     <letteral>s</letteral>; there must, however, be some Lojban consonant at the end.</para>
-    <para> <indexterm type="general"><primary>names</primary><secondary>restrictions on form of</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>restrictions on form of</secondary></indexterm> Names are not permitted to have the sequences 
+    <para> <indexterm type="general"><primary>names</primary><secondary>restrictions on form of</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>restrictions on form of</secondary></indexterm> Cmevla are not permitted to have the sequences 
     <valsi>la</valsi>, 
     <valsi>lai</valsi>, or 
-    <valsi>doi</valsi> embedded in them, unless the sequence is immediately preceded by a consonant. These minor restrictions are due to the fact that all Lojban cmene embedded in a speech stream will be preceded by one of these words or by a pause. With one of these words embedded, the cmene might break up into valid Lojban words followed by a shorter cmene. However, break-up cannot happen after a consonant, because that would imply that the word before the 
+    <valsi>doi</valsi> embedded in them, unless the sequence is immediately preceded by a consonant. These minor restrictions are due to the fact that all Lojban cmevla embedded in a speech stream will be preceded by one of these words or by a pause. With one of these words embedded, the cmevla might break up into valid Lojban words followed by a shorter cmevla. However, break-up cannot happen after a consonant, because that would imply that the word before the 
     <valsi>la</valsi>, or whatever, ended in a consonant without pause, which is impossible.</para>
     <para> 
 
@@ -1739,33 +1739,33 @@ The prefix method would render the mathematical concept as
     <jbophrase>NEderlants.</jbophrase> cannot be misheard as 
     <jbophrase>NEder lants.</jbophrase>, because 
     <jbophrase>NEder</jbophrase> with no following pause is not a possible Lojban word.</para>
-    <para> <indexterm type="general"><primary>names</primary><secondary>alternatives for restricted sequences in</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>alternatives for restricted sequences in</secondary></indexterm> There are close alternatives to these forbidden sequences that can be used in Lojbanizing names, such as 
+    <para> <indexterm type="general"><primary>names</primary><secondary>alternatives for restricted sequences in</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>alternatives for restricted sequences in</secondary></indexterm> There are close alternatives to these forbidden sequences that can be used in Lojbanizing names, such as 
     <valsi>ly</valsi>, 
     <valsi>lei</valsi>, and 
     <valsi>dai</valsi> or 
     
     <valsi>do'i</valsi>, that do not cause these problems.</para>
-    <para> <indexterm type="general"><primary>cmene</primary><secondary>rules for</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>rules for</secondary></indexterm> Lojban cmene are identifiable as word forms by the following characteristics:</para>
+    <para> <indexterm type="general"><primary>cmevla</primary><secondary>rules for</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>rules for</secondary></indexterm> Lojban cmevla are identifiable as word forms by the following characteristics:</para>
     
     <orderedlist>
       <listitem>
-        <para> <indexterm type="general"><primary>cmene</primary><secondary>consonant clusters permitted in</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>final letter in</secondary></indexterm> They must end in one or more consonants. There are no rules about how many consonants may appear in a cluster in cmene, provided that each consonant pair (whether standing by itself, or as part of a larger cluster) is a permissible pair.</para>
+        <para> <indexterm type="general"><primary>cmevla</primary><secondary>consonant clusters permitted in</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>final letter in</secondary></indexterm> They must end in one or more consonants. There are no rules about how many consonants may appear in a cluster in cmevla, provided that each consonant pair (whether standing by itself, or as part of a larger cluster) is a permissible pair.</para>
       </listitem>
       <listitem>
-        <para> <indexterm type="general"><primary>diphthongs</primary><secondary>specific to cmene</secondary></indexterm>  <indexterm type="general"><primary>diphthongs</primary><secondary>specific to names</secondary></indexterm>  <indexterm type="general"><primary>uy diphthong</primary><secondary>in cmene</secondary></indexterm>  <indexterm type="general"><primary>iy diphthong</primary><secondary>in cmene</secondary></indexterm> They may contain the letter y as a normal, non-hyphenating vowel. They are the only kind of Lojban word that may contain the two diphthongs 
+        <para> <indexterm type="general"><primary>diphthongs</primary><secondary>specific to cmevla</secondary></indexterm>  <indexterm type="general"><primary>diphthongs</primary><secondary>specific to names</secondary></indexterm>  <indexterm type="general"><primary>uy diphthong</primary><secondary>in cmevla</secondary></indexterm>  <indexterm type="general"><primary>iy diphthong</primary><secondary>in cmevla</secondary></indexterm> They may contain the letter y as a normal, non-hyphenating vowel. They are the only kind of Lojban word that may contain the two diphthongs 
         <diphthong>iy</diphthong> and 
         <diphthong>uy</diphthong>.</para>
       </listitem>
       <listitem>
-        <para> <indexterm type="general"><primary>names</primary><secondary>requirement for pause after</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>requirement for pause after</secondary></indexterm> They are always followed in speech by a pause after the final consonant, written as 
+        <para> <indexterm type="general"><primary>names</primary><secondary>requirement for pause after</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>requirement for pause after</secondary></indexterm> They are always followed in speech by a pause after the final consonant, written as 
         <letteral>.</letteral>.</para>
       </listitem>
       <listitem>
-        <para> <indexterm type="general"><primary>capitalization</primary><secondary>use of</secondary></indexterm>  <indexterm type="general"><primary>capitalization</primary><secondary>for unusual stress in names</secondary></indexterm>  <indexterm type="general"><primary>capitalization</primary><secondary>use in names</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>stress in</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>stress in</secondary></indexterm> They may be stressed on any syllable; if this syllable is not the penultimate one, it must be capitalized when writing. Neither names nor words that begin sentences are capitalized in Lojban, so this is the only use of capital letters.</para>
+        <para> <indexterm type="general"><primary>capitalization</primary><secondary>use of</secondary></indexterm>  <indexterm type="general"><primary>capitalization</primary><secondary>for unusual stress in names</secondary></indexterm>  <indexterm type="general"><primary>capitalization</primary><secondary>use in names</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>stress in</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>stress in</secondary></indexterm> They may be stressed on any syllable; if this syllable is not the penultimate one, it must be capitalized when writing. Neither names nor words that begin sentences are capitalized in Lojban, so this is the only use of capital letters.</para>
         
       </listitem>
     </orderedlist>
-    <para> <indexterm type="general"><primary>names</primary><secondary>from Lojban words</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>from Lojban words</secondary></indexterm> Names meeting these criteria may be invented, Lojbanized from names in other languages, or formed by appending a consonant onto a cmavo, a gismu, a fu'ivla or a lujvo. Some cmene built from Lojban words are:</para>
+    <para> <indexterm type="general"><primary>names</primary><secondary>from Lojban words</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>from Lojban words</secondary></indexterm> Cmevla meeting these criteria may be invented, Lojbanized from names in other languages, or formed by appending a consonant onto a cmavo, a gismu, a fu'ivla or a lujvo. Some cmevla built from Lojban words are:</para>
     <example xml:id="example-random-id-qjj1" role="interlinear-gloss-example">
       <title>
         <indexterm type="example"><primary>One</primary><secondary>the</secondary></indexterm>
@@ -1823,7 +1823,7 @@ The prefix method would render the mathematical concept as
       </interlinear-gloss>
     <para>from the gismu <valsi>nobli</valsi>, with rafsi <rafsi>nol</rafsi>, meaning <quote>noble</quote>.</para>
     </example>
-    <para role="indent"><indexterm type="general"><primary>cmene</primary><secondary>algorithm for</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>algorithm for</secondary></indexterm> To Lojbanize a name from the various natural languages, apply the following rules:</para>
+    <para role="indent"><indexterm type="general"><primary>cmevla</primary><secondary>algorithm for</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>algorithm for</secondary></indexterm> To Lojbanize a name from the various natural languages, apply the following rules:</para>
     <orderedlist>
       <listitem>
         <para>Eliminate double consonants and silent letters.</para>
@@ -1842,11 +1842,11 @@ The prefix method would render the mathematical concept as
         
       </listitem>
       <listitem>
-        <para> <indexterm type="general"><primary>cmene</primary><secondary>avoiding impermissible consonant clusters in</secondary></indexterm> If the name contains an impermissible consonant pair, insert a vowel between the consonants: 
+        <para> <indexterm type="general"><primary>cmevla</primary><secondary>avoiding impermissible consonant clusters in</secondary></indexterm> If the name contains an impermissible consonant pair, insert a vowel between the consonants: 
         <letteral>y</letteral> is recommended.</para>
       </listitem>
       <listitem>
-        <para> <indexterm type="general"><primary>cmene</primary><secondary>proscribed syllables in</secondary></indexterm> No cmene may have the syllables 
+        <para> <indexterm type="general"><primary>cmevla</primary><secondary>proscribed syllables in</secondary></indexterm> No cmevla may have the syllables 
         <valsi>la</valsi>, 
         <valsi>lai</valsi>, or 
         <valsi>doi</valsi> in them, unless immediately preceded by a consonant. If these combinations are present, they must be converted to something else. Possible substitutions include 
@@ -2096,20 +2096,20 @@ The prefix method would render the mathematical concept as
         <para> <indexterm type="general"><primary>pause</primary><secondary>between words</secondary></indexterm>  <indexterm type="general"><primary>pause</primary><secondary>proscribed within words</secondary></indexterm> Any two words may have a pause between them; it is always illegal to pause in the middle of a word, because that breaks up the word into two words.</para>
       </listitem>
       <listitem>
-        <para> <indexterm type="general"><primary>pause</primary><secondary>and consonant-final words</secondary></indexterm>  <indexterm type="general"><primary>consonant-final words</primary><secondary>necessity for pause after</secondary></indexterm> Every word ending in a consonant must be followed by a pause. Necessarily, all such words are cmene.</para>
+        <para> <indexterm type="general"><primary>pause</primary><secondary>and consonant-final words</secondary></indexterm>  <indexterm type="general"><primary>consonant-final words</primary><secondary>necessity for pause after</secondary></indexterm> Every word ending in a consonant must be followed by a pause. Necessarily, all such words are cmevla.</para>
       </listitem>
       <listitem>
-        <para> <indexterm type="general"><primary>pause</primary><secondary>and vowel-initial words</secondary></indexterm>  <indexterm type="general"><primary>vowel-initial words</primary><secondary>necessity for pause before</secondary></indexterm> Every word beginning with a vowel must be preceded by a pause. Such words are either cmavo, fu'ivla, or cmene; all gismu and lujvo begin with consonants.</para>
+        <para> <indexterm type="general"><primary>pause</primary><secondary>and vowel-initial words</secondary></indexterm>  <indexterm type="general"><primary>vowel-initial words</primary><secondary>necessity for pause before</secondary></indexterm> Every word beginning with a vowel must be preceded by a pause. Such words are either cmavo, fu'ivla, or cmevla; all gismu and lujvo begin with consonants.</para>
       </listitem>
       <listitem>
-        <para> <indexterm type="general"><primary>pause</primary><secondary>and cmene</secondary></indexterm>  <indexterm type="general"><primary>cmene</primary><secondary>rules for pause before</secondary></indexterm> Every cmene must be preceded by a pause, unless the immediately preceding word is one of the cmavo 
+        <para> <indexterm type="general"><primary>pause</primary><secondary>and cmevla</secondary></indexterm>  <indexterm type="general"><primary>cmevla</primary><secondary>rules for pause before</secondary></indexterm> Every cmevla must be preceded by a pause, unless the immediately preceding word is one of the cmavo 
         <valsi>la</valsi>, 
         <valsi>lai</valsi>, 
         <valsi>la'i</valsi>, or 
-        <valsi>doi</valsi> (which is why those strings are forbidden in cmene). However, the situation triggering this rule rarely occurs.</para>
+        <valsi>doi</valsi> (which is why those strings are forbidden in cmevla). However, the situation triggering this rule rarely occurs.</para>
       </listitem>
       <listitem>
-        <para> <indexterm type="general"><primary>pause</primary><secondary>and final-syllable stress</secondary></indexterm>  <indexterm type="general"><primary>final syllable stress</primary><secondary>rules for pause after</secondary></indexterm>  <indexterm type="general"><primary>stress</primary><secondary>final syllable</secondary><tertiary>rules for pause after</tertiary></indexterm> If the last syllable of a word bears the stress, and a brivla follows, the two must be separated by a pause, to prevent confusion with the primary stress of the brivla. In this case, the first word must be either a cmavo or a cmene with unusual stress (which already ends with a pause, of course).</para>
+        <para> <indexterm type="general"><primary>pause</primary><secondary>and final-syllable stress</secondary></indexterm>  <indexterm type="general"><primary>final syllable stress</primary><secondary>rules for pause after</secondary></indexterm>  <indexterm type="general"><primary>stress</primary><secondary>final syllable</secondary><tertiary>rules for pause after</tertiary></indexterm> If the last syllable of a word bears the stress, and a brivla follows, the two must be separated by a pause, to prevent confusion with the primary stress of the brivla. In this case, the first word must be either a cmavo or a cmevla with unusual stress (which already ends with a pause, of course).</para>
       </listitem>
       <listitem>
         <para> <indexterm type="general"><primary>pause</primary><secondary>and Cy-form cmavo</secondary></indexterm>  <indexterm type="general"><primary>cmavo</primary><secondary>rules for pause after Cy-form</secondary></indexterm>  <indexterm type="general"><primary>Cy-form cmavo</primary><secondary>rules for pause after</secondary></indexterm> A cmavo of the form 
@@ -2468,7 +2468,7 @@ This section contains examples of making and scoring lujvo. First, we will start
     <valsi valid='maybe'>blokle</valsi>; "lotlei" and "lotkle" are only slightly worse; 
     <valsi valid='maybe'>lo'ikle</valsi> suffers because of its apostrophe, and 
     <valsi valid='maybe'>lo'irlei</valsi> because of having both apostrophe and hyphen.</para>
-    <para>Our third example will result in forming both a lujvo and a name from the tanru 
+    <para>Our third example will result in forming both a lujvo and a cmevla from the tanru 
     <jbophrase>logji bangu girzu</jbophrase>, or 
     <quote>logical-language group</quote> in English. (<quote>The Logical Language Group</quote> is the name of the publisher of this book and the organization for the promotion of Lojban.)</para>
     <para>The available rafsi are 
@@ -2478,7 +2478,7 @@ This section contains examples of making and scoring lujvo. First, we will start
     <rafsi>-bau-</rafsi>, and 
     <rafsi>-bang-</rafsi>; and 
     <rafsi>-gri-</rafsi> and 
-    <rafsi>-girzu</rafsi>, and (for name purposes only) 
+    <rafsi>-girzu</rafsi>, and (for cmevla purposes only) 
     <rafsi>-gir-</rafsi> and 
     <rafsi>-girz-</rafsi>. The resulting 12 lujvo possibilities are:</para>
     <simplelist type="horiz" columns="3">
@@ -2498,7 +2498,7 @@ This section contains examples of making and scoring lujvo. First, we will start
       <member><rafsi>logj</rafsi><rafsi>-bau</rafsi><rafsi>-girzu</rafsi></member>
       <member><rafsi>logj</rafsi><rafsi>-bang</rafsi><rafsi>-girzu</rafsi></member>
     </simplelist>
-    <para>and the 12 name possibilities are:</para>
+    <para>and the 12 cmevla possibilities are:</para>
     <simplelist type="horiz" columns="3">
       <member><rafsi>loj</rafsi><rafsi>-ban</rafsi><rafsi>-gir</rafsi></member>
       <member><rafsi>loj</rafsi><rafsi>-bau</rafsi><rafsi>-gir</rafsi></member>

--- a/chapters/06.xml
+++ b/chapters/06.xml
@@ -1602,7 +1602,7 @@
     </example>
     <para role="indent"> <indexterm type="general"><primary>vocative word</primary><secondary>phrase following</secondary></indexterm> In these cases, the person being addressed is obvious from the context. However, a vocative word (more precisely, one or more cmavo of COI, possibly followed by 
     <valsi>doi</valsi>, or else just 
-    <valsi>doi</valsi> by itself) can be followed by one of several kinds of phrases, all of which are intended to indicate the addressee. The most common case is a name:</para>
+    <valsi>doi</valsi> by itself) can be followed by one of several kinds of phrases, all of which are intended to indicate the addressee. The most common case is a cmevla (name-word):</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-Bega">
       <title>
         <anchor xml:id="c6e11d3"/>
@@ -1614,7 +1614,7 @@
         <natlang>Hello, John.</natlang>
       </interlinear-gloss>
     </example>
-    <para role="indent">A pause is required (for morphological reasons) between a member of COI and a name. You can use 
+    <para role="indent">A pause is required (for morphological reasons) between a member of COI and a cmevla. You can use 
     <valsi>doi</valsi> instead of a pause:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-QmzB">
       <title>
@@ -1638,7 +1638,7 @@
         <natlang>John!</natlang>
       </interlinear-gloss>
     </example>
-    <para role="indent"> <indexterm type="general"><primary>vocative phrase</primary><secondary>implicit descriptor on</secondary></indexterm>  <indexterm type="general"><primary>vocative phrase</primary><secondary>with sumti without descriptor</secondary></indexterm>  <indexterm type="general"><primary>vocative phrase</primary><secondary>forms of</secondary></indexterm> In place of a name, a description may appear, lacking its descriptor, which is understood to be 
+    <para role="indent"> <indexterm type="general"><primary>vocative phrase</primary><secondary>implicit descriptor on</secondary></indexterm>  <indexterm type="general"><primary>vocative phrase</primary><secondary>with sumti without descriptor</secondary></indexterm>  <indexterm type="general"><primary>vocative phrase</primary><secondary>forms of</secondary></indexterm> In place of a cmevla, a description may appear, lacking its descriptor, which is understood to be 
     <valsi>le</valsi>:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-V530">
       <title>
@@ -1725,7 +1725,7 @@
     <para>Names have been used freely as sumti throughout this chapter without too much explanation. The time for the explanation has now come.</para>
     <para> <indexterm type="general"><primary>name words</primary><secondary>recognition of</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>two kinds of</secondary></indexterm> First of all, there are two different kinds of things usually called 
     <quote>names</quote> when talking about Lojban. The naming predicates of 
-    <xref linkend="section-basic-descriptors"/> are just ordinary predicates which are being used in a special sense. In addition, though, there is a class of Lojban words which are used only to name things: these can be recognized by the fact that they end in a consonant followed by a pause. Some examples:</para>
+    <xref linkend="section-basic-descriptors"/> are just ordinary predicates which are being used in a special sense. In addition, though, there is a class of Lojban words which are used only to name things: cmevla, or “name-words”. These can be recognized by the fact that they end in a consonant followed by a pause. Some examples:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-u0zY">
       <title>
         <anchor xml:id="c6e12d1"/>
@@ -1776,13 +1776,13 @@
     <valsi>la</valsi> and 
     <valsi>lai</valsi> in 
     <xref linkend="example-random-id-PrGp"/> and 
-    <xref linkend="example-random-id-H8z5"/> respectively. The only difference is that these descriptors are followed by Lojban name-words. And in fact, the only difference between descriptors of selma'o LA (these three) and of selma'o LE (all the other descriptors) is that the former can be followed by name-words, whereas the latter cannot.</para>
+    <xref linkend="example-random-id-H8z5"/> respectively. The only difference is that these descriptors are followed by Lojban name-words (i.e. cmevla). And in fact, the only difference between descriptors of selma'o LA (these three) and of selma'o LE (all the other descriptors) is that the former can be followed by name-words, whereas the latter cannot.</para>
     
     <para><indexterm type="general"><primary>doi</primary><secondary>effect on necessity for pause before name-word</secondary></indexterm>  <indexterm type="general"><primary>LA selma'o</primary><secondary>effect on necessity for pause before name-word</secondary></indexterm>  <indexterm type="general"><primary>name-words</primary><secondary>pause requirements before</secondary></indexterm>  <indexterm type="general"><primary>name-words</primary><secondary>limitations on</secondary></indexterm> There are certain limitations on the form of name-words in Lojban. In particular, they cannot contain the letter-sequences (or sound-sequences) 
     
     <valsi>la</valsi>, 
     <valsi>lai</valsi>, or 
-    <valsi>doi</valsi> unless a consonant immediately precedes within the name. Reciprocally, every name not preceded by 
+    <valsi>doi</valsi> unless a consonant immediately precedes within the name-word. Reciprocally, every name-word not preceded by 
     <valsi>la</valsi>, 
     <valsi>lai</valsi>, 
     <valsi>la'i</valsi>, or 
@@ -1810,9 +1810,9 @@
     <para role="indent">In 
     <xref linkend="example-random-id-qLiB"/> and 
     <xref linkend="example-random-id-qLIJ"/>, 
-    <cmevla>.djan.</cmevla> appears with a pause before it as well as after it, because the preceding word is not one of the four special cases. These rules force names to always be separable from the general word-stream.</para>
+    <cmevla>.djan.</cmevla> appears with a pause before it as well as after it, because the preceding word is not one of the four special cases. These rules force name-words to always be separable from the general word-stream.</para>
     <para> <indexterm type="general"><primary>names</primary><secondary>multiple</secondary></indexterm> Unless some other rule prevents it (such as the rule that 
-    <valsi>zo</valsi> is always followed by a single word, which is quoted), multiple names may appear wherever one name is permitted, each with its terminating pause:</para>
+    <valsi>zo</valsi> is always followed by a single word, which is quoted), multiple name-words may appear wherever one name-word is permitted, each with its terminating pause:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-cw3p">
       <title>
         
@@ -1835,7 +1835,7 @@
         
       </interlinear-gloss>
     </example>
-    <para role="indent"><indexterm type="general"><primary>name-words</primary><secondary>permissible consonant combinations</secondary></indexterm> A name may not contain any consonant combination that is illegal in Lojban words generally: the 
+    <para role="indent"><indexterm type="general"><primary>name-words</primary><secondary>permissible consonant combinations</secondary></indexterm> A name-word may not contain any consonant combination that is illegal in Lojban words generally: the 
     <quote>impermissible consonant clusters</quote> of Lojban morphology (explained in 
     
     
@@ -1900,13 +1900,13 @@
         <natlang>Lojban</natlang>
       </interlinear-gloss>
     </example>
-    <para role="indent"> <indexterm type="general"><primary>names from vowel-final base</primary><secondary>commonly used consonant endings</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>borrowing from other languages</secondary></indexterm> When borrowing names from another language which end in a vowel, or when turning a Lojban brivla (all of which end in vowels) into a name, the vowel may be removed or an arbitrary consonant added. It is common (but not required) to use the consonants 
+    <para role="indent"> <indexterm type="general"><primary>names from vowel-final base</primary><secondary>commonly used consonant endings</secondary></indexterm>  <indexterm type="general"><primary>names</primary><secondary>borrowing from other languages</secondary></indexterm> When borrowing names from another language which end in a vowel, or when turning a Lojban brivla (all of which end in vowels) into a cmevla, the vowel may be removed or an arbitrary consonant added. It is common (but not required) to use the consonants 
     
     <rafsi>s</rafsi> or 
     <rafsi>n</rafsi> when borrowing vowel-final names from English; speakers of other languages may wish to use other consonant endings.</para>
     
     <para> <indexterm type="general"><primary>names with la</primary><secondary>implicit quantifier for</secondary></indexterm> The implicit quantifier for name sumti of the form 
-    <valsi>la</valsi> followed by a name is 
+    <valsi>la</valsi> followed by a cmevla (name-word) is 
     <valsi>su'o</valsi>, just as for 
     <valsi>la</valsi> followed by a selbri.</para>
   </section>

--- a/chapters/07.xml
+++ b/chapters/07.xml
@@ -2099,7 +2099,7 @@
     <valsi>do</valsi>.</para>
     <para> <indexterm type="general"><primary>pro-sumti rafsi</primary><secondary>anticipated use of for abbreviating inconvenient forms</secondary></indexterm> An anticipated use of rafsi for cmavo in the 
     
-    <valsi>fo'a</valsi> series is to express lujvo which can't be expressed in a convenient rafsi form, because they are too long to express, or are formally inconvenient (fu'ivla, cmene, and so forth.) An example would be:</para>
+    <valsi>fo'a</valsi> series is to express lujvo which can't be expressed in a convenient rafsi form, because they are too long to express, or are formally inconvenient (fu'ivla, cmevla, and so forth.) An example would be:</para>
     
     
     

--- a/chapters/08.xml
+++ b/chapters/08.xml
@@ -1380,7 +1380,7 @@
     <title><anchor xml:id="c8s9"/>Relative clauses in vocative phrases</title>
     <para> <indexterm type="lojban-word"><primary>DOI selma'o</primary></indexterm>  <indexterm type="lojban-word"><primary>COI selma'o</primary></indexterm> Vocative phrases are explained in more detail in 
     <xref linkend="section-vocative-syntax"/>. Briefly, they are a method of indicating who a sentence or discourse is addressed to: of identifying the intended listener. They take three general forms, all beginning with cmavo from selma'o COI or DOI (called 
-    <quote>vocative words</quote>; there can be one or many), followed by either a name, a selbri, or a sumti. Here are three examples:</para>
+    <quote>vocative words</quote>; there can be one or many), followed by either a cmevla, a selbri, or a sumti. Here are three examples:</para>
     <example xml:id="example-random-id-qMG8" role="interlinear-gloss-example">
       <title>
         <anchor xml:id="c8e9d1"/>

--- a/chapters/13.xml
+++ b/chapters/13.xml
@@ -87,7 +87,7 @@
   <indexterm type="general"><primary>attitudinals</primary><secondary>word-form for primary</secondary></indexterm> The primary Lojban attitudinals are all the cmavo of the form VV or V'V: one of the few cases where cmavo have been classified solely by their form. There are 39 of these cmavo: all 25 possible vowel pairs of the form V'V, the four standard diphthongs (<valsi>.ai</valsi>, 
     <valsi>.au</valsi>, 
     <valsi>.ei</valsi>, and 
-    <valsi>.oi</valsi>), and the ten more diphthongs that are permitted only in these attitudinal indicators and in names and borrowings (<valsi>.ia</valsi>, 
+    <valsi>.oi</valsi>), and the ten more diphthongs that are permitted only in these attitudinal indicators and in Lojbanized names and borrowings (<valsi>.ia</valsi>, 
     <valsi>.ie</valsi>, 
     <valsi>.ii</valsi>, 
     <valsi>.io</valsi>, 
@@ -2718,10 +2718,10 @@
     <valsi>nai</valsi> too often vital to interpretation of a protocol signal, as explained later in this section.</para>
     
     <para> <indexterm type="general"><primary>vocatives</primary><secondary>grammar overview</secondary></indexterm> The grammar of vocatives is explained in 
-    <xref linkend="section-vocative-syntax"/>; but in brief, a vocative may be followed by a name (without 
+    <xref linkend="section-vocative-syntax"/>; but in brief, a vocative may be followed by a cmevla (without 
     <valsi>la</valsi>), a description (without 
     <valsi>le</valsi> or its relatives), a complete sumti, or nothing at all (if the addressee is obvious from the context). There is an elidable terminator, 
-    <valsi>do'u</valsi> (of selma'o DOhU) which is almost never required unless no name (or other indication of the addressee) follows the vocative.</para>
+    <valsi>do'u</valsi> (of selma'o DOhU) which is almost never required unless no cmevla (or other indication of the addressee) follows the vocative.</para>
     
     <para> <indexterm type="general"><primary>vocatives</primary><secondary>and definition of &quot;you&quot;</secondary></indexterm>  <indexterm type="general"><primary>you</primary><secondary>defining</secondary></indexterm> Using any vocative except 
     <valsi>mi'e</valsi> (explained below) implicitly defines the meaning of the pro-sumti 
@@ -2731,9 +2731,9 @@
     <quote>writer</quote> and 
     <quote>reader</quote>.</para>
     <para> <indexterm type="general"><primary>vocatives</primary><secondary>notation convention symbol &quot;X&quot;</secondary></indexterm> In the following list of vocatives, the translations include the symbol X. This represents the name (or identifying description, or whatever) of the listener.</para>
-    <para> <indexterm type="general"><primary>doi</primary><secondary>effect on pause before name</secondary></indexterm>  <indexterm type="general"><primary>pause before name</primary><secondary>effect of doi</secondary></indexterm> The cmavo 
+    <para> <indexterm type="general"><primary>doi</primary><secondary>effect on pause before cmevla</secondary></indexterm>  <indexterm type="general"><primary>pause before cmevla</primary><secondary>effect of doi</secondary></indexterm> The cmavo 
     <valsi>doi</valsi> is the general-purpose vocative. Unlike the cmavo of selma'o COI, explained below, 
-    <valsi>doi</valsi> can precede a name directly without an intervening pause. It is not considered a scale, and 
+    <valsi>doi</valsi> can precede a cmevla directly without an intervening pause. It is not considered a scale, and 
     <jbophrase valid="false">doinai</jbophrase> is not grammatical. In general, 
     <valsi>doi</valsi> needs no translation in English (we just use names by themselves without any preceding word, although in poetic styles we sometimes say 
     <quote>Oh X</quote>, which is equivalent to 
@@ -2744,15 +2744,15 @@
     <jbophrase>doi .ionai</jbophrase> means 
     
     <quote>You there!</quote>.</para>
-    <para> <indexterm type="general"><primary>COI selma'o</primary><secondary>effect on pause before name</secondary></indexterm>  <indexterm type="general"><primary>pause before name</primary><secondary>effect of vocatives of COI</secondary></indexterm> All members of selma'o COI require a pause when used immediately before a name, in order to prevent the name from absorbing the COI word. This is unlike selma'o DOI and LA, which do not require pauses because the syllables of these cmavo are not permitted to be embedded in a Lojban name. When calling out to someone, this is fairly natural, anyway. 
+    <para> <indexterm type="general"><primary>COI selma'o</primary><secondary>effect on pause before cmevla</secondary></indexterm>  <indexterm type="general"><primary>pause before cmevla</primary><secondary>effect of vocatives of COI</secondary></indexterm> All members of selma'o COI require a pause when used immediately before a cmevla, in order to prevent the cmevla from absorbing the COI word. This is unlike selma'o DOI and LA, which do not require pauses because the syllables of these cmavo are not permitted to be embedded in a cmevla. When calling out to someone, this is fairly natural, anyway. 
     <quote>Hey! John!</quote> is thus a better translation of 
     <jbophrase>ju'i .djan.</jbophrase> than 
     
-    <quote>Hey John!</quote>. No pause is needed if the vocative reference is something other than a name, as in the title of the Lojban journal, 
+    <quote>Hey John!</quote>. No pause is needed if the vocative reference is something other than a cmevla, as in the title of the Lojban journal, 
     <jbophrase>ju'i lobypli</jbophrase>.</para>
     
     <para>(Alternatively, 
-    <valsi>doi</valsi> can be inserted between the COI cmavo and the name, making a pause unnecessary: 
+    <valsi>doi</valsi> can be inserted between the COI cmavo and the cmevla, making a pause unnecessary: 
     <jbophrase>coi doi djan.</jbophrase>)</para>
     <cmavo-list>
       <cmavo-entry>

--- a/chapters/17.xml
+++ b/chapters/17.xml
@@ -173,7 +173,7 @@
   </section>
   <section xml:id="section-upper-case">
     <title><anchor xml:id="c17s3"/>Upper and lower cases</title>
-    <para> <indexterm type="general"><primary>lower case letters</primary><secondary>use in Lojban</secondary></indexterm>  <indexterm type="general"><primary>capital letters</primary><secondary>use in Lojban</secondary></indexterm>  <indexterm type="general"><primary>stress</primary><secondary>irregular marked with upper-case</secondary></indexterm>  <indexterm type="general"><primary>lower-case letters</primary><secondary>English usage contrasted with Lojban</secondary></indexterm>  <indexterm type="general"><primary>lower-case letters</primary><secondary>Lojban usage contrasted with English</secondary></indexterm>  <indexterm type="general"><primary>upper-case letters</primary><secondary>English usage contrasted with Lojban</secondary></indexterm>  <indexterm type="general"><primary>upper-case letters</primary><secondary>Lojban usage contrasted with English</secondary></indexterm> Lojban doesn't use lower-case (small) letters and upper-case (capital) letters in the same way that English does; sentences do not begin with an upper-case letter, nor do names. However, upper-case letters are used in Lojban to mark irregular stress within names, thus:</para>
+    <para> <indexterm type="general"><primary>lower case letters</primary><secondary>use in Lojban</secondary></indexterm>  <indexterm type="general"><primary>capital letters</primary><secondary>use in Lojban</secondary></indexterm>  <indexterm type="general"><primary>stress</primary><secondary>irregular marked with upper-case</secondary></indexterm>  <indexterm type="general"><primary>lower-case letters</primary><secondary>English usage contrasted with Lojban</secondary></indexterm>  <indexterm type="general"><primary>lower-case letters</primary><secondary>Lojban usage contrasted with English</secondary></indexterm>  <indexterm type="general"><primary>upper-case letters</primary><secondary>English usage contrasted with Lojban</secondary></indexterm>  <indexterm type="general"><primary>upper-case letters</primary><secondary>Lojban usage contrasted with English</secondary></indexterm> Lojban doesn't use lower-case (small) letters and upper-case (capital) letters in the same way that English does; sentences do not begin with an upper-case letter, nor do names. However, upper-case letters are used in Lojban to mark irregular stress within cmevla, thus:</para>
     
     
     
@@ -289,8 +289,8 @@
     <valsi>bu</valsi> to itself, but more than one 
     <valsi>bu</valsi> may be attached to a word; thus 
     <jbophrase>.abubu</jbophrase> is legal, if ugly. (Its meaning is not defined, but it is presumably different from 
-    <valsi>.abu</valsi>.) It does not matter if the word is a cmavo, a cmene, or a brivla. All such words suffixed by 
-    <valsi>bu</valsi> are treated grammatically as if they were cmavo belonging to selma'o BY. However, if the word is a cmene it is always necessary to precede and follow it by a pause, because otherwise the cmene may absorb preceding or following words.</para>
+    <valsi>.abu</valsi>.) It does not matter if the word is a cmavo, a cmevla, or a brivla. All such words suffixed by 
+    <valsi>bu</valsi> are treated grammatically as if they were cmavo belonging to selma'o BY. However, if the word is a cmevla it is always necessary to precede and follow it by a pause, because otherwise the cmevla may absorb preceding or following words.</para>
     <para> 
 
   <indexterm type="general"><primary>happy face</primary><secondary>example</secondary></indexterm>  <indexterm type="general"><primary>smiley face</primary><secondary>example</secondary></indexterm>
@@ -586,7 +586,7 @@
     
     <valsi>lau</valsi> of selma'o LAU. 
     
-    <valsi>lau</valsi> must always be followed by a BY word; the interpretation of the BY word is changed from a lerfu to a punctuation mark. Typically, this BY word would be a name or brivla with a 
+    <valsi>lau</valsi> must always be followed by a BY word; the interpretation of the BY word is changed from a lerfu to a punctuation mark. Typically, this BY word would be a cmevla or brivla with a 
     
     <valsi>bu</valsi> suffix.</para>
     <para> <indexterm type="general"><primary>punctuation lerfu words</primary><secondary>rationale for lau</secondary></indexterm> Why is 
@@ -1034,9 +1034,9 @@
     
     <quote>ess cue ell</quote> or 
     <quote>sequel</quote>.</para>
-    <para> <indexterm type="general"><primary>lerfu words</primary><secondary>as a basis for acronym names</secondary></indexterm>  <indexterm type="general"><primary>acronyms</primary><secondary>using names based on lerfu words</secondary></indexterm> In Lojban, a name can be almost any sequence of sounds that ends in a consonant and is followed by a pause. The easiest way to Lojbanize acronym names is to glue the lerfu words together, using 
+    <para> <indexterm type="general"><primary>lerfu words</primary><secondary>as a basis for acronym names</secondary></indexterm>  <indexterm type="general"><primary>acronyms</primary><secondary>using names based on lerfu words</secondary></indexterm> In Lojban, a cmevla can be almost any sequence of sounds that ends in a consonant and is followed by a pause. The easiest way to Lojbanize acronym names is to glue the lerfu words together, using 
     
-    <letteral>'</letteral> wherever two vowels would come together (pauses are illegal in names) and adding a final consonant:</para>
+    <letteral>'</letteral> wherever two vowels would come together (pauses are illegal in cmevla) and adding a final consonant:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-736i">
       <title>
         <anchor xml:id="c17e12d1"/>
@@ -1057,7 +1057,7 @@
     <para> <indexterm type="general"><primary>bu</primary><secondary>omitting in acronyms names based on lerfu words</secondary></indexterm>  <indexterm type="general"><primary>acronyms names based on lerfu words</primary><secondary>omitting bu</secondary></indexterm> Some compression can be done by leaving out 
     <valsi>bu</valsi> after vowel lerfu words (except for 
     <valsi>.y.bu</valsi>, wherein the 
-    <valsi>bu</valsi> cannot be omitted without ambiguity). Compression is moderately important because it's hard to say long names without introducing an involuntary (and illegal) pause:</para>
+    <valsi>bu</valsi> cannot be omitted without ambiguity). Compression is moderately important because it's hard to say long cmevla without introducing an involuntary (and illegal) pause:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-0sin">
       <title>
         <anchor xml:id="c17e12d2"/>
@@ -1099,7 +1099,7 @@
         <natlang>… SQL. IBM. NYC.</natlang>
       </interlinear-gloss>
     </example>
-    <para role="indent"> <indexterm type="general"><primary>acronyms</primary><secondary>as lerfu strings using &quot;me&quot;</secondary></indexterm>  <indexterm type="general"><primary>lerfu strings</primary><secondary>as acronyms using &quot;me&quot;</secondary></indexterm> One more alternative to these lengthy names is to use the lerfu string itself prefixed with 
+    <para role="indent"> <indexterm type="general"><primary>acronyms</primary><secondary>as lerfu strings using &quot;me&quot;</secondary></indexterm>  <indexterm type="general"><primary>lerfu strings</primary><secondary>as acronyms using &quot;me&quot;</secondary></indexterm> One more alternative to these lengthy cmevla is to use the lerfu string itself prefixed with 
     <valsi>me</valsi>, the cmavo that makes sumti into selbri:</para>
     
     <example role="interlinear-gloss-example" xml:id="example-random-id-iMRB">
@@ -1112,7 +1112,7 @@
       </interlinear-gloss>
     </example>
     <para role="indent">This works because 
-    <valsi>la</valsi>, the cmavo that normally introduces names used as sumti, may also be used before a predicate to indicate that the predicate is a (meaningful) name:</para>
+    <valsi>la</valsi>, the cmavo that normally introduces cmevla used as sumti, may also be used before a predicate to indicate that the predicate is a (meaningful) name:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-7KLi">
       <title>
         <anchor xml:id="c17e12d5"/>

--- a/chapters/19.xml
+++ b/chapters/19.xml
@@ -610,7 +610,7 @@
     <para role="indent">At the beginning of a text, the following non-bridi are also permitted:</para>
     <itemizedlist role="bullets">
       <listitem>
-        <para>one or more names (to indicate direct address without 
+        <para>one or more cmevla (to indicate direct address without 
         
         <valsi>doi</valsi>, see 
         <xref linkend="chapter-sumti"/>)</para>
@@ -1058,7 +1058,7 @@
     <valsi>lo'u</valsi> (of selma'o LOhU) and 
     <valsi>le'u</valsi> (of selma'o LEhU) are used to surround a quotation that is not necessarily grammatical Lojban. However, the text must consist of morphologically correct Lojban words (as defined in 
     <xref linkend="chapter-morphology"/>), so that the 
-    <valsi>le'u</valsi> can be picked out reliably. The words need not be meaningful, but they must be recognizable as cmavo, brivla, or cmene. Quotation with 
+    <valsi>le'u</valsi> can be picked out reliably. The words need not be meaningful, but they must be recognizable as cmavo, brivla, or cmevla. Quotation with 
     <valsi>lo'u</valsi> is essential to quoting ungrammatical Lojban for teaching in the language, the equivalent of the * that is used in English to mark such errors:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-IUz8">
       <title>
@@ -1216,7 +1216,7 @@
     <para role="noindent">where 
     <valsi>gy</valsi> stands for 
     <valsi>glico</valsi>. Other popular choices of delimiting words are 
-    <cmevla>.kuot.</cmevla>, a Lojban name which sounds like the English word 
+    <cmevla>.kuot.</cmevla>, a cmevla which sounds like the English word 
     <quote>quote</quote>, and the word 
     <valsi>zoi</valsi> itself. Another possibility is a Lojban word suggesting the topic of the quotation.</para>
     <para>Within written text, the Lojban written word used as a delimiting word may not appear, whereas within spoken text, the sound of the delimiting word may not be uttered. This leads to occasional breakdowns of audio-visual isomorphism: 
@@ -1253,7 +1253,7 @@
     <quote>gyrations</quote>. Such borderline cases should be avoided as a matter of good style.</para>
     <para>It should be noted particularly that 
     <valsi>zoi</valsi> quotation is the only way to quote rafsi, specifically CCV rafsi, because they are not Lojban words, and 
-    <valsi>zoi</valsi> quotation is the only way to quote things which are not Lojban words. (CVC and CVV rafsi look like names and cmavo respectively, and so can be quoted using other methods.) For example:</para>
+    <valsi>zoi</valsi> quotation is the only way to quote things which are not Lojban words. (CVC and CVV rafsi look like cmevla and cmavo respectively, and so can be quoted using other methods.) For example:</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-Eeya">
       <title>
         <anchor xml:id="c19e10d5"/>
@@ -1329,14 +1329,14 @@
     <para role="noindent">and says that Bob is both the name and the thing named, an unlikely situation. People are not names.</para>
     <para>(In 
     <xref linkend="example-random-id-56m5"/> through 
-    <xref linkend="example-random-id-qITB"/>, the name 
+    <xref linkend="example-random-id-qITB"/>, the cmevla 
     <cmevla>bab.</cmevla> was separated from a preceding 
     <valsi>zo</valsi> by a pause, thus: 
-    <jbophrase>zo .bab.</jbophrase>. The reason for this extra pause is that all Lojban names must be separated by pause from any preceding word other than 
+    <jbophrase>zo .bab.</jbophrase>. The reason for this extra pause is that all cmevla must be separated by pause from any preceding word other than 
     <valsi>la</valsi>, 
     <valsi>lai</valsi>, 
     <valsi>la'i</valsi> (all of selma'o LA) and 
-    <valsi>doi</valsi> (of selma'o DOI). There are numerous other cmavo that may precede a name: of these, 
+    <valsi>doi</valsi> (of selma'o DOI). There are numerous other cmavo that may precede a cmevla: of these, 
     <valsi>zo</valsi> is one of the most common.)</para>
     <para>The cmavo 
     <valsi>la'o</valsi> also belongs to selma'o ZOI, and is mentioned here for completeness, although it does not signal the beginning of a quotation. Instead, 
@@ -1418,7 +1418,7 @@
         <natlang>I saw <emphasis>George</emphasis>.</natlang>
       </interlinear-gloss>
     </example>
-    <para role="indent">Note the pause before the name 
+    <para role="indent">Note the pause before the cmevla 
     <cmevla>djordj.</cmevla>, which serves to separate it unambiguously from the 
     <valsi>ba'e</valsi>. Alternatively, the 
     <valsi>ba'e</valsi> can be moved to a position before the 
@@ -1808,7 +1808,7 @@
     </example>
     <para role="indent">The parser will reject 
     <jbophrase valid="false">zo .djan. si .djordj.</jbophrase>, because in that context 
-    <cmevla>djordj.</cmevla> is a name (of selma'o CMENE) rather than a quoted word.</para>
+    <cmevla>djordj.</cmevla> is a bare cmevla rather than a quoted word.</para>
     <para>Note: The current machine parser does not implement 
     <valsi>si</valsi> erasure.</para>
     
@@ -1854,7 +1854,7 @@
     <xref linkend="example-random-id-SszI"/>, 
     <jbophrase>le blanu .zdan.</jbophrase> is ungrammatical, but clearly reflects the speaker's original intention to say 
     <jbophrase>le blanu zdani</jbophrase>. However, the 
-    <valsi>zdani</valsi> was cut off before the end and changed into a name. The entire ungrammatical 
+    <valsi>zdani</valsi> was cut off before the end and changed into a cmevla. The entire ungrammatical 
     <valsi>le</valsi> construct is erased and replaced by 
     <jbophrase>le xekri zdani</jbophrase>.</para>
     <para>Note: The current machine parser does not implement 

--- a/chapters/20.xml
+++ b/chapters/20.xml
@@ -197,7 +197,7 @@
       <xref linkend="section-vocative-scales"/>)
     </bridgehead>
     
-    <para>When prefixed to a name, description, or sumti, produces a vocative: a phrase which indicates who is being spoken to (or who is speaking). Vocatives are used in conversational protocols, including greeting, farewell, and radio communication. Terminated by 
+    <para>When prefixed to a cmevla, description, or sumti, produces a vocative: a phrase which indicates who is being spoken to (or who is speaking). Vocatives are used in conversational protocols, including greeting, farewell, and radio communication. Terminated by 
     <xref linkend="DOhU"/>. See 
     <xref linkend="DOI"/>.</para>
     <interlinear-gloss>
@@ -239,7 +239,7 @@
     </bridgehead>
     
     <para>The non-specific vocative indicator. May be used with or without 
-    <xref linkend="COI"/>. No pause is required between “doi” and a following name. See 
+    <xref linkend="COI"/>. No pause is required between “doi” and a following cmevla. See 
     <xref linkend="DOhU"/>.</para>
     <interlinear-gloss>
       <jbo>doi frank. mi tavla do</jbo>

--- a/chapters/21.xml
+++ b/chapters/21.xml
@@ -164,7 +164,7 @@
 <anchor xreflabel="YACC rule #517" xml:id="cll_yacc-517"/> CEhE_517         /* afterthought term list connective */
 %token
 <anchor xml:id="y518"/>
-<anchor xreflabel="YACC rule #518" xml:id="cll_yacc-518"/> CMENE_518        /* names; require consonant end, then pause no
+<anchor xreflabel="YACC rule #518" xml:id="cll_yacc-518"/> CMEVLA_518       /* name-words; require consonant end, then pause no
                                    LA or DOI selma'o embedded, pause before if
 
                                    vowel initial and preceded by a vowel */
@@ -174,7 +174,7 @@
 
 %token
 <anchor xml:id="y520"/>
-<anchor xreflabel="YACC rule #520" xml:id="cll_yacc-520"/> COI_520          /* vocative marker permitted inside names; must
+<anchor xreflabel="YACC rule #520" xml:id="cll_yacc-520"/> COI_520          /* vocative marker permitted inside cmevla; must
                                    always be followed by pause or DOI */
 %token
 <anchor xml:id="y521"/>
@@ -694,7 +694,7 @@ the 900 series rules are found in the lexer.  */
 <anchor xreflabel="YACC rule #3" xml:id="cll_yacc-3"/> text_C_3                :
 <xref linkend="cll_yacc-4"/>
    /* Only indicators which follow certain selma'o:
-    cmene,
+    cmevla,
 <xref linkend="cll_yacc-607"/>,
 <xref linkend="cll_yacc-571"/>, and the lexer_K and lexer_S I_roots and compounds,
     and at the start of text(_0), will survive the lexer; all other valid ones
@@ -1693,7 +1693,7 @@ the 900 series rules are found in the lexer.  */
 
 
 <anchor xml:id="y404"/>
-<anchor xreflabel="YACC rule #404" xml:id="cll_yacc-404"/> cmene_404               :
+<anchor xreflabel="YACC rule #404" xml:id="cll_yacc-404"/> cmevla_404               :
 <xref linkend="cll_yacc-405"/>
                         |
 <xref linkend="cll_yacc-405"/>
@@ -1701,12 +1701,12 @@ the 900 series rules are found in the lexer.  */
                         ;
 
 <anchor xml:id="y405"/>
-<anchor xreflabel="YACC rule #405" xml:id="cll_yacc-405"/> cmene_A_405             :
+<anchor xreflabel="YACC rule #405" xml:id="cll_yacc-405"/> cmevla_A_405             :
 <xref linkend="cll_yacc-518"/>  /* pause */
                         |
 <xref linkend="cll_yacc-405"/>
 <xref linkend="cll_yacc-518"/>  /* pause*/
-/* multiple CMENE are identified morphologically (by the lexer) - - separated by
+/* multiple CMEVLA are identified morphologically (by the lexer) - - separated by
    consonant &amp; pause */
                         ;
 
@@ -3872,7 +3872,7 @@ the 900 series rules are found in the lexer.  */
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term>cmene_404</term>
+        <term>cmevla_404</term>
         <listitem>
           <para>
           <xref linkend="cll_yacc-97"/>,
@@ -3881,7 +3881,7 @@ the 900 series rules are found in the lexer.  */
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term>CMENE_518</term>
+        <term>CMEVLA_518</term>
         <listitem>
           <para>
             <xref linkend="cll_yacc-405"/>
@@ -3889,7 +3889,7 @@ the 900 series rules are found in the lexer.  */
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term>cmene_A_405</term>
+        <term>cmevla_A_405</term>
         <listitem>
           <para>
           <xref linkend="cll_yacc-404"/>,
@@ -7070,7 +7070,7 @@ the 900 series rules are found in the lexer.  */
         <!-- <xref linkend="cll_yacc-0"/> --> text
         <subscript>0</subscript>=</term>
         <listitem>
-          <para>[NAI ...] [CMENE ... # | (indicators &amp; free ...)] [joik-jek] text-1
+          <para>[NAI ...] [CMEVLA ... # | (indicators &amp; free ...)] [joik-jek] text-1
           <anchor xml:id="b2"/>
           <anchor xreflabel="BNF rule #2" xml:id="cll_bnf-2"/>
           <!-- <xref linkend="cll_yacc-2"/> --></para>
@@ -7360,7 +7360,7 @@ the 900 series rules are found in the lexer.  */
         <term>sumti-6
         <subscript>97</subscript>=</term>
         <listitem>
-          <para>(LAhE # | NAhE BO #) [relative-clauses] sumti /LUhU#/ | KOhA # | lerfu-string /BOI#/ | LA # [relative-clauses] CMENE ... # | (LA | LE) # sumti-tail /KU#/ | LI # mex /LOhO#/ | ZO any-word # | LU text /LIhU#/ | LOhU any-word ... LEhU # | ZOI any-word anything any-word #
+          <para>(LAhE # | NAhE BO #) [relative-clauses] sumti /LUhU#/ | KOhA # | lerfu-string /BOI#/ | LA # [relative-clauses] CMEVLA ... # | (LA | LE) # sumti-tail /KU#/ | LI # mex /LOhO#/ | ZO any-word # | LU text /LIhU#/ | LOhU any-word ... LEhU # | ZOI any-word anything any-word #
           <anchor xml:id="b111"/>
           <anchor xreflabel="BNF rule #111" xml:id="cll_bnf-111"/>
           <!-- <xref linkend="cll_yacc-111"/> --></para>
@@ -7913,7 +7913,7 @@ the 900 series rules are found in the lexer.  */
         <term>free
         <subscript>32</subscript>=</term>
         <listitem>
-          <para>SEI # [terms [CU #]] selbri /SEhU/ | SOI # sumti [sumti] /SEhU/ | vocative [relative-clauses] selbri [relative-clauses] /DOhU/ | vocative [relative-clauses] CMENE ... # [relative-clauses] /DOhU/ | vocative [sumti] /DOhU/ | (number | lerfu-string) MAI | TO text /TOI/ | XI # (number | lerfu-string) /BOI/ | XI # VEI # mex /VEhO/
+          <para>SEI # [terms [CU #]] selbri /SEhU/ | SOI # sumti [sumti] /SEhU/ | vocative [relative-clauses] selbri [relative-clauses] /DOhU/ | vocative [relative-clauses] CMEVLA ... # [relative-clauses] /DOhU/ | vocative [sumti] /DOhU/ | (number | lerfu-string) MAI | TO text /TOI/ | XI # (number | lerfu-string) /BOI/ | XI # VEI # mex /VEhO/
           <anchor xml:id="b415"/>
           <anchor xreflabel="BNF rule #415" xml:id="cll_bnf-415"/>
           <!-- <xref linkend="cll_yacc-415"/> --></para>
@@ -8163,7 +8163,7 @@ the 900 series rules are found in the lexer.  */
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term>CMENE</term>
+        <term>CMEVLA</term>
         <listitem>
           <para>
           <xref linkend="cll_bnf-32"/>


### PR DESCRIPTION
Replacement of the appropriate instances of "cmene", "name" and "Lojban name" with "cmevla", or occasionally "Lojbanized name".