### PR TITLE
remove {le ka do xunre kei} example completely

### DIFF
--- a/chapters/11.xml
+++ b/chapters/11.xml
@@ -490,19 +490,6 @@
     
     
     <quote>-ity</quote>.)</para>
-    <para> <indexterm type="general"><primary>property description</primary></indexterm> We can also move the property description to the x1 place of 
-    
-    <xref linkend="example-random-id-v3Ba"/>, producing:</para>
-    <example role="interlinear-gloss-example" xml:id="example-random-id-proQ">
-      <title>
-        <anchor xml:id="c11e4d4"/>
-      </title>
-      <interlinear-gloss>
-        <jbo>le ka do xunre [kei] cu cnino mi</jbo>
-        <gloss>The proposition-of you being-red -- -- is-new to--me.</gloss>
-        <natlang>Your redness is new to me.</natlang>
-      </interlinear-gloss>
-    </example>
     <para role="indent"> <indexterm type="general"><primary>beach</primary><secondary>example</secondary></indexterm>  <indexterm type="general"><primary>sunburn</primary><secondary>example</secondary></indexterm> It would be suitable to use 
     <xref linkend="example-random-id-v3Ba"/> and 
     <xref linkend="example-random-id-proQ"/> to someone who has returned from the beach with a sunburn.</para>


### PR DESCRIPTION
{le ka do xunre kei cu cnino mi} is imho bad because

1. what to fill cnino3 with?
2. less important (and fixable in another commit): should be {du'u}, not {ka} anyway.