### PR TITLE
chapters/16: Fix erratum in section 9.

### DIFF
--- a/chapters/16.xml
+++ b/chapters/16.xml
@@ -1025,9 +1025,9 @@
         <anchor xml:id="c16e9d2"/>
       </title>
       <interlinear-gloss>
-        <jbo>naku zo'u la djan. klama</jbo>
-        <gloss>It-is-not-the-case-that : that-named John comes.</gloss>
-        <natlang>It is false that: John comes.</natlang>
+        <jbo>naku zo'u mi klama le zarci</jbo>
+        <gloss>It-is-not-the-case-that : I go-to the store.</gloss>
+        <natlang>It is false that: I go to the store.</natlang>
       </interlinear-gloss>
     </example>
     <para role="indent"> <indexterm type="general"><primary>negation in prenex</primary><secondary>effects of position</secondary></indexterm> However, 


### PR DESCRIPTION
This erratum isn't previously documented AFAIK. The bridi simply don't match, but it's easy enough to copy the former to the latter and update the surrounding gloss.

I built this locally and checked the PDF version to make sure it looks right.