### PR TITLE
Added standard pronunciation of {u} to IPA chapter

### DIFF
--- a/chapters/03.xml
+++ b/chapters/03.xml
@@ -1734,6 +1734,15 @@
         <quote>thin</quote> (but not 
         <quote>then</quote>).
     </td></tr>
+    <tr><td><phrase role="IPA">[u]</phrase></td>
+      <td>
+		The preferred pronunciation of Lojban
+		<letteral>u</letteral>. As in the French 
+		<quote xml:lang="fr">boule</quote> or German
+		<quote xml:lang="de">Stuhl</quote>. There is no exact English equivalent of this sound. The nearest sound appears in 
+		<quote>boot</quote> or 
+		<quote>cool</quote>, but many dialects pronounce these with an off-glide, which should not be present when speaking Lojban.
+    </td></tr>
     <tr><td><phrase role="IPA">[v]</phrase></td>
       <td>
         The preferred pronunciation of Lojban 


### PR DESCRIPTION
It was the only vowel for which no standard is in there.