### PR TITLE
Fewer insults

### DIFF
--- a/chapters/03.xml
+++ b/chapters/03.xml
@@ -738,14 +738,13 @@
         <para>The specific pairs 
         <morphology>cx</morphology>, 
         <morphology>kx</morphology>, 
-        <morphology>xc</morphology>, 
-        <morphology>xk</morphology>, and 
-        <morphology>mz</morphology> are forbidden.
+        <morphology>xc</morphology>, and
+        <morphology>xk</morphology> are forbidden.
         </para>
       </listitem>
     </orderedlist>
     <para>   <indexterm type="general"><primary>y</primary><secondary>use in avoiding forbidden consonant pairs</secondary></indexterm> These rules apply to all kinds of words, even Lojbanized names. If a name would normally contain a forbidden consonant pair, a 
-    <letteral>y</letteral> can be inserted to break up the pair:
+    <letteral>y</letteral> can be inserted to break up the pair.
     </para>
     <example role="pronunciation-example" xml:id="example-random-id-k2cK">
       <title>
@@ -757,7 +756,7 @@
         <anchor xml:id="c3e6d1"/>
       </title>
       <pronunciation>
-        <jbo>djeimyz.</jbo>
+        <jbo>djeimz.</jbo>
         <ipa>[dʒɛj məzʔ]</ipa>
         <natlang>James</natlang>
       </pronunciation>
@@ -765,7 +764,7 @@
     <para role="indent">The regular English pronunciation of 
     <quote>James</quote>, which is 
     <phrase role="IPA">[dʒɛjmz]</phrase>, would Lojbanize as 
-    <cmevla valid="false">djeimz.</cmevla>, which contains a forbidden consonant pair.</para>
+    <cmevla valid="false">djeimz.</cmevla></para>
   </section>
   <section xml:id="section-initial-pairs">
     <title><anchor xml:id="c3s7"/>Initial Consonant Pairs</title>

--- a/chapters/06.xml
+++ b/chapters/06.xml
@@ -1839,18 +1839,14 @@
     <quote>impermissible consonant clusters</quote> of Lojban morphology (explained in 
     
     
-    <xref linkend="section-clusters"/>). Thus 
-    <cmevla valid="false">djeimz.</cmevla> is not a valid version of 
-    <quote>James</quote> (because 
-    <morphology>mz</morphology> is invalid): 
-    <cmevla>djeimyz</cmevla> will suffice. Similarly, 
+    <xref linkend="section-clusters"/>). For example, 
     <valsi>la</valsi> may be replaced by 
     <valsi>ly</valsi>, 
     <valsi>lai</valsi> by 
     <jbophrase>ly'i</jbophrase>, 
     <valsi>doi</valsi> by 
     <valsi>do'i</valsi> or 
-    <valsi>dai</valsi>. Here are a few examples:</para>
+    <valsi>dai</valsi>. Here are a few example names:</para>
     
   <para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-cw4p">

--- a/chapters/14.xml
+++ b/chapters/14.xml
@@ -321,13 +321,13 @@
         <anchor xml:id="c14e4d1"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .ija la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .ija la djeimz. ninmu</jbo>
         <gloss>That-named John is-a-man or that-named James is-a-woman.</gloss>
       </interlinear-gloss>
     </example>
     <para role="indent">Here we have two separate Lojban bridi, 
     <jbophrase>la djan. nanmu</jbophrase> and 
-    <jbophrase>la djeimyz. ninmu</jbophrase>. These bridi are connected by 
+    <jbophrase>la djeimz. ninmu</jbophrase>. These bridi are connected by
     <valsi>.i</valsi><valsi>ja</valsi>, the ijek for the truth function 
     <phrase role="logical-vowel">A</phrase>. The 
     <valsi>i</valsi> portion of the ijek tells us that we are dealing with separate sentences here. Similarly, we can now say:</para>
@@ -336,7 +336,7 @@
         <anchor xml:id="c14e4d2"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .ije la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .ije la djeimz. ninmu</jbo>
         <gloss>That-named John is-a-man and that-named James is-a-woman.</gloss>
       </interlinear-gloss>
     </example>
@@ -345,7 +345,7 @@
         <anchor xml:id="c14e4d3"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .ijo la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .ijo la djeimz. ninmu</jbo>
         <gloss>That-named John is-a-man if-and-only-if that-named James is-a-woman.</gloss>
       </interlinear-gloss>
     </example>
@@ -354,7 +354,7 @@
         <anchor xml:id="c14e4d4"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .iju la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .iju la djeimz. ninmu</jbo>
         <gloss>That-named John is-a-man whether-or-not that-named James is-a-woman.</gloss>
       </interlinear-gloss>
     </example>
@@ -374,7 +374,7 @@
         <anchor xml:id="c14e4d5"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .inajo la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .inajo la djeimz. ninmu</jbo>
         <gloss>That-named John is-not-a-man if-and-only-if that-named James is-a-woman.</gloss>
       </interlinear-gloss>
     </example>
@@ -383,7 +383,7 @@
         <anchor xml:id="c14e4d6"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .ijonai la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .ijonai la djeimz. ninmu</jbo>
         <gloss>That-named John is-a-man if-and-only-if that-named James is-not-a-woman.</gloss>
       </interlinear-gloss>
     </example>
@@ -402,7 +402,7 @@
         <anchor xml:id="c14e4d8"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .ijanai la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .ijanai la djeimz. ninmu</jbo>
         <gloss>That-named John is-a-man or that-named James is-not-a-woman.</gloss>
         <natlang>John is a man if James is a woman.</natlang>
       </interlinear-gloss>
@@ -425,7 +425,7 @@
         <anchor xml:id="c14e4d9"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. ninmu .ijanai la djeimyz. ninmu</jbo>
+        <jbo>la djan. ninmu .ijanai la djeimz. ninmu</jbo>
         <gloss>That-named John is-a-woman if that-named James is-a-woman.</gloss>
       </interlinear-gloss>
     </example>
@@ -446,7 +446,7 @@
         <anchor xml:id="c14e4d10"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .inaja la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .inaja la djeimz. ninmu</jbo>
         <gloss>That-named John is-not-a-man or that-named James is-a-woman.</gloss>
         <natlang>John is a man only if James is a woman.</natlang>
         <natlang>If John is a man, then James is a woman.</natlang>
@@ -461,7 +461,7 @@
         <anchor xml:id="c14e4d11"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .iseju la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .iseju la djeimz. ninmu</jbo>
         <natlang>Whether or not John is a man, James is a woman.</natlang>
       </interlinear-gloss>
     </example>
@@ -500,7 +500,7 @@
         <anchor xml:id="c14e5d2"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djan. nanmu .ija la djeimyz. ninmu</jbo>
+        <jbo>la djan. nanmu .ija la djeimz. ninmu</jbo>
         <natlang>John is a man or James is a woman (or both)</natlang>
       </interlinear-gloss>
     </example>
@@ -512,7 +512,7 @@
         <anchor xml:id="c14e5d3"/>
       </title>
       <interlinear-gloss>
-        <jbo>ga la djan. nanmu gi la djeimyz. ninmu</jbo>
+        <jbo>ga la djan. nanmu gi la djeimz. ninmu</jbo>
         <natlang>Either John is a man or James is a woman (or both).</natlang>
       </interlinear-gloss>
     </example>
@@ -536,7 +536,7 @@
         <anchor xml:id="c14e5d4"/>
       </title>
       <interlinear-gloss>
-        <jbo>ge la djan. nanmu gi la djeimyz. ninmu</jbo>
+        <jbo>ge la djan. nanmu gi la djeimz. ninmu</jbo>
         <natlang>(It is true that) both John is a man and James is a woman.</natlang>
       </interlinear-gloss>
     </example>
@@ -545,14 +545,14 @@
         <anchor xml:id="c14e5d5"/>
       </title>
       <interlinear-gloss>
-        <jbo>gu la djan. nanmu gi la djeimyz. ninmu</jbo>
+        <jbo>gu la djan. nanmu gi la djeimz. ninmu</jbo>
         <natlang>It is true that John is a man, whether or not James is a woman.</natlang>
       </interlinear-gloss>
     </example>
     <para role="indent">It is worth emphasizing that 
     <xref linkend="example-random-id-qgMN"/> does not assert that James is (or is not) a woman. The 
     <valsi>gu</valsi> which indicates that 
-    <jbophrase>la djeimyz. ninmu</jbophrase> may be true or false is unfortunately rather remote from the bridi thus affected.</para>
+    <jbophrase>la djeimz. ninmu</jbophrase> may be true or false is unfortunately rather remote from the bridi thus affected.</para>
     <para>Perhaps the most important of the truth functions commonly expressed in forethought is TFTT, which can be paraphrased as 
     <quote>if ... then ...</quote>:</para>
     
@@ -561,7 +561,7 @@
         <anchor xml:id="c14e5d6"/>
       </title>
       <interlinear-gloss>
-        <jbo>ganai la djan. nanmu gi la djeimyz. ninmu</jbo>
+        <jbo>ganai la djan. nanmu gi la djeimz. ninmu</jbo>
         <gloss>Either that-named John is-not-a-man, or that-named James is-a-woman.</gloss>
         <natlang>If John is a man, then James is a woman.</natlang>
       </interlinear-gloss>
@@ -606,7 +606,7 @@
         <anchor xml:id="c14e5d8"/>
       </title>
       <interlinear-gloss>
-        <jbo>gonai la djan. nanmu gi la djeimyz. ninmu</jbo>
+        <jbo>gonai la djan. nanmu gi la djeimz. ninmu</jbo>
         <natlang>John is not a man if and only if James is a woman.</natlang>
         <natlang>Either John is a man or James is a woman but not both.</natlang>
       </interlinear-gloss>
@@ -619,7 +619,7 @@
         <anchor xml:id="c14e5d9"/>
       </title>
       <interlinear-gloss>
-        <jbo>go la djan. nanmu ginai la djeimyz. ninmu</jbo>
+        <jbo>go la djan. nanmu ginai la djeimz. ninmu</jbo>
         <natlang>John is a man if and only if James is not a woman.</natlang>
         <natlang>Either John is a man or James is a woman but not both.</natlang>
       </interlinear-gloss>
@@ -635,7 +635,7 @@
         <anchor xml:id="c14e5d10"/>
       </title>
       <interlinear-gloss>
-        <jbo>ge la djan. nanmu ginai la djeimyz. ninmu</jbo>
+        <jbo>ge la djan. nanmu ginai la djeimz. ninmu</jbo>
         <natlang>John is a man and James is not a woman.</natlang>
       </interlinear-gloss>
     </example>
@@ -644,7 +644,7 @@
         <anchor xml:id="c14e5d11"/>
       </title>
       <interlinear-gloss>
-        <jbo>ganai la djan. nanmu ginai la djeimyz. ninmu</jbo>
+        <jbo>ganai la djan. nanmu ginai la djeimz. ninmu</jbo>
         <natlang>John is not a man or James is not a woman.</natlang>
       </interlinear-gloss>
     </example>
@@ -2174,7 +2174,7 @@
         <gloss>I choose that-named Alice from-that-named Frank</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
-        <jbo>… ce la .alis. ce la djeimyz.</jbo>
+        <jbo>… ce la .alis. ce la djeimz.</jbo>
         <gloss>… and-member that-named Alice and-member that-named James.</gloss>
         <natlang>I choose Alice from among Frank, Alice, and James.</natlang>
       </interlinear-gloss>
@@ -2222,7 +2222,7 @@
         <indexterm type="example"><primary>brothers</primary></indexterm>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. bruna la djordj.</jbo>
+        <jbo>la djeimz. bruna la djordj.</jbo>
         <gloss>That-named James is-the-brother-of that-named George.</gloss>
       </interlinear-gloss>
     </example>
@@ -2239,7 +2239,7 @@
         <indexterm type="example"><primary>brothers</primary></indexterm>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. .e la djordj. bruna</jbo>
+        <jbo>la djeimz. .e la djordj. bruna</jbo>
         <gloss>That-named James and that-named George is-a-brother.</gloss>
       </interlinear-gloss>
     </example>
@@ -2254,7 +2254,7 @@
         <indexterm type="example"><primary>brothers</primary></indexterm>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. jo'u</jbo>
+        <jbo>la djeimz. jo'u</jbo>
         <gloss>That-named James in-common-with that-named</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
@@ -2272,7 +2272,7 @@
         <indexterm type="example"><primary>brothers</primary></indexterm>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. joi</jbo>
+        <jbo>la djeimz. joi</jbo>
         <gloss>That-named James massed-with</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
@@ -2294,7 +2294,7 @@
         <indexterm type="example"><primary>respectively</primary></indexterm>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. fa'u la djordj.</jbo>
+        <jbo>la djeimz. fa'u la djordj.</jbo>
         <gloss>That-named James jointly-in-order-with that-named George</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
@@ -2313,7 +2313,7 @@
         <anchor xml:id="c14e14d13"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. .e la djordj. prami</jbo>
+        <jbo>la djeimz. .e la djordj. prami</jbo>
         <gloss>That-named James and that-named George love</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
@@ -2327,11 +2327,11 @@
         <anchor xml:id="c14e14d14"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. prami la meris. .ije la djordj. prami</jbo>
+        <jbo>la djeimz. prami la meris. .ije la djordj. prami</jbo>
         <gloss>That-named James loves that-named Mary, and that-named George loves</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
-        <jbo>… la meris. .ije la djeimyz. prami la martas.</jbo>
+        <jbo>… la meris. .ije la djeimz. prami la martas.</jbo>
         <gloss>… that-named Mary, and that-named James loves that-named Martha,</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
@@ -2347,7 +2347,7 @@
         <anchor xml:id="c14e14d15"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. ce'e la meris. pe'e</jbo>
+        <jbo>la djeimz. ce'e la meris. pe'e</jbo>
         <gloss>That-named James [plus] that-named Mary [joint]</gloss>
       </interlinear-gloss>
       <interlinear-gloss>
@@ -2362,7 +2362,7 @@
         <anchor xml:id="c14e14d16"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. fa'u la djordj. prami re mensi</jbo>
+        <jbo>la djeimz. fa'u la djordj. prami re mensi</jbo>
         <gloss>That-named James and-respectively that-named George love two sisters.</gloss>
       </interlinear-gloss>
     </example>
@@ -2440,7 +2440,7 @@
         <anchor xml:id="c14e15d5"/>
       </title>
       <interlinear-gloss>
-        <jbo>la djeimyz. ce[bo] la djordj. pi'u</jbo>
+        <jbo>la djeimz. ce[bo] la djordj. pi'u</jbo>
         <gloss>That-named James and-set that-named George cross-product</gloss>
       </interlinear-gloss>
       <interlinear-gloss>

--- a/chapters/14.xml
+++ b/chapters/14.xml
@@ -1711,8 +1711,8 @@
         <anchor xml:id="c14e12d12"/>
       </title>
       <interlinear-gloss>
-        <jbo>mi viska pa nanmu .ije mi viska pa ninmu</jbo>
-        <gloss>I see a man, and I see a woman.</gloss>
+        <jbo>mi viska pa mlatu .ije mi viska pa gerku</jbo>
+        <gloss>I see a cat, and I see a dog.</gloss>
       </interlinear-gloss>
     </example>
     <para role="noindent">to</para>
@@ -1721,8 +1721,8 @@
         <anchor xml:id="c14e12d13"/>
       </title>
       <interlinear-gloss>
-        <jbo>mi viska pa nanmu .e pa ninmu</jbo>
-        <gloss>I see a man and a woman.</gloss>
+        <jbo>mi viska pa mlatu .e pa gerku</jbo>
+        <gloss>I see a cat and a dog.</gloss>
       </interlinear-gloss>
     </example>
     <para role="noindent">there is a great temptation to reduce further to:</para>
@@ -1732,15 +1732,15 @@
         <indexterm type="example"><primary>man-woman</primary></indexterm>
       </title>
       <interlinear-gloss>
-        <jbo>mi viska pa nanmu je ninmu</jbo>
-        <gloss>I see a man and woman.</gloss>
+        <jbo>mi viska pa mlatu je gerku</jbo>
+        <gloss>I see a cat and dog.</gloss>
       </interlinear-gloss>
     </example>
     <para role="indent">But 
-    <xref linkend="example-random-id-ag8r"/> means that you see one thing which is both a man and a woman simultaneously! A 
-    <jbophrase>nanmu je ninmu</jbophrase> is a manwoman, a presumably non-existent creature who is both a 
-    <valsi>nanmu</valsi> and a 
-    <valsi>ninmu</valsi>.</para>
+    <xref linkend="example-random-id-ag8r"/> means that you see one thing which is both a cat and a dog simultaneously! A 
+    <jbophrase>mlatu je gerku</jbophrase> is a catdog, a presumably non-existent creature who is both a 
+    <valsi>mlatu</valsi> and a 
+    <valsi>gerku</valsi>.</para>
   </section>
   <section xml:id="section-truth-and-connective-questions">
     <title><anchor xml:id="c14s13"/>Truth questions and connective questions</title>

--- a/chapters/20.xml
+++ b/chapters/20.xml
@@ -178,7 +178,7 @@
     
     <para>Joins multiple terms into a termset. Termsets are used to associate several terms for logical connectives, for equal quantifier scope, or for special constructs in tenses.</para>
     <interlinear-gloss>
-      <jbo>mi ce'e do pe'e je la--djan. ce'e la--djeimyz. cu pendo</jbo>
+      <jbo>mi ce'e do pe'e je la--djan. ce'e la--djeimz. cu pendo</jbo>
       <gloss>I [,] you [joint] and John [,] James -- are-friends-of.</gloss>
       <natlang>I am a friend of you, and John is a friend of James.</natlang>
     </interlinear-gloss>
@@ -377,7 +377,7 @@
     <para>Indicates the beginning of two logically connected sumti, bridi-tails, or various other things. Logical connections include “both ... and”, “either ... or”, “if ... then”, and so on. See 
     <xref linkend="GI"/>.</para>
     <interlinear-gloss>
-      <jbophrase>ga la djan. nanmu gi la djeimyz. ninmu</jbophrase>
+      <jbophrase>ga la djan. nanmu gi la djeimz. ninmu</jbophrase>
       <natlang>Either John is a man or James is a woman (or both).</natlang>
     </interlinear-gloss>
     <bridgehead>
@@ -416,7 +416,7 @@
     <xref linkend="GUhA"/>, or 
     <xref linkend="JOI"/>.</para>
     <interlinear-gloss>
-      <jbophrase>ge la djan. nanmu gi la djeimyz. ninmu</jbophrase>
+      <jbophrase>ge la djan. nanmu gi la djeimz. ninmu</jbophrase>
       <natlang>(It is true that) both John is a man and James is a woman.</natlang>
     </interlinear-gloss>
     <bridgehead>
@@ -965,7 +965,7 @@
     <para>Precedes a logical or non-logical connective that joins two termsets. Termsets (see 
     <xref linkend="CEhE"/>) are used to associate several terms for logical connectives, for equal quantifier scope, or for special constructs in tenses.</para>
     <interlinear-gloss>
-      <jbo>mi ce'e do pe'e je la--djan. ce'e la--djeimyz. cu pendo</jbo>
+      <jbo>mi ce'e do pe'e je la--djan. ce'e la--djeimz. cu pendo</jbo>
       <gloss>I [,] you [joint] and John [,] James -- are-friends-of.</gloss>
       <natlang>I am a friend of you, and John is a friend of James.</natlang>
     </interlinear-gloss>


### PR DESCRIPTION
Remove the -mz- rule, which ka'u was meant to insult the late James Cooke Brown. Additionally, change the infamous "manwoman" paragraph. The rest of Chapter 14 is largely unchanged; whether to change "James is a woman" can be independent of this change.