### PR TITLE
Chapter 2: try to make explanation of {le vi ...} less misleading

### DIFF
--- a/chapters/02.xml
+++ b/chapters/02.xml
@@ -61,22 +61,22 @@
       These examples all describe relationships between John and Sam. However, in English, we use the noun
       <quote>father</quote>
       to describe a static relationship in
-      <xref linkend="example-random-id-qIuj" />
-      , the verb
+      <xref linkend="example-random-id-qIuj" />,
+      the verb
       <quote>hits</quote>
       to describe an active relationship in
-      <xref linkend="example-random-id-qiuQ" />
-      , and the adjective
+      <xref linkend="example-random-id-qiuQ" />,
+      and the adjective
       <quote>taller</quote>
       to describe an attributive relationship in
       <xref linkend="example-random-id-qIuS" />. In Lojban we make no such grammatical distinctions; these three sentences, when expressed in Lojban, are structurally identical. The same part of speech is used to represent the relationship. In formal logic this whole structure is called a
-      <quote>predication</quote>
-      ; in Lojban it is called a
-      <valsi>bridi</valsi>
-      , and the central part of speech is the
+      <quote>predication</quote>;
+      in Lojban it is called a
+      <valsi>bridi</valsi>,
+      and the central part of speech is the
       <valsi>selbri</valsi>. Logicians refer to the things thus related as
-      <quote>arguments</quote>
-      , while Lojbanists call them
+      <quote>arguments</quote>,
+      while Lojbanists call them
       <valsi>sumti</valsi>. These Lojban terms will be used for the rest of the book.
     </para>
     <mediaobject>
@@ -133,17 +133,16 @@
       </indexterm>
       In Lojban, each selbri has a specified number and type of arguments, known collectively as its
       <quote>place structure</quote>. The simplest kind of selbri consists of a single root word, called a
-      <valsi>gismu</valsi>
-      , and the definition in a dictionary gives the place structure explicitly. The primary task of constructing a Lojban sentence, after choosing the relationship itself, is deciding what you will use to fill in the sumti places.
+      <valsi>gismu</valsi>,
+      and the definition in a dictionary gives the place structure explicitly. The primary task of constructing a Lojban sentence, after choosing the relationship itself, is deciding what you will use to fill in the sumti places.
     </para>
     <para>
       This book uses the Lojban terms
-      <valsi>bridi</valsi>
-      ,
-      <valsi>sumti</valsi>
-      , and
-      <valsi>selbri</valsi>
-      , because it is best to come to understand them independently of the English associations of the corresponding words, which are only roughly similar in meaning anyhow.
+      <valsi>bridi</valsi>,
+      <valsi>sumti</valsi>,
+      and
+      <valsi>selbri</valsi>,
+      because it is best to come to understand them independently of the English associations of the corresponding words, which are only roughly similar in meaning anyhow.
     </para>
     <para>
 
@@ -156,36 +155,29 @@
   </section>
   <section xml:id="section-pronunciation">
     <title><anchor xml:id="c2s2" />Pronunciation</title>
-    <para>      <indexterm type="general"><primary>pronunciation</primary><secondary>quick-tour version</secondary>      </indexterm>      Detailed pronunciation and spelling rules are given in      <xref linkend="chapter-phonology" />      , but what follows will keep the reader from going too far astray while digesting this chapter.
+    <para>      <indexterm type="general"><primary>pronunciation</primary><secondary>quick-tour version</secondary>      </indexterm>      Detailed pronunciation and spelling rules are given in      <xref linkend="chapter-phonology" />, but what follows will keep the reader from going too far astray while digesting this chapter.
     </para>
     <para>
       <indexterm type="general"><primary>vowels</primary><secondary>pronunciation of</secondary>
         <tertiary>quick-tour version</tertiary>
       </indexterm>
       Lojban has six recognized vowels:
-      <letteral>a</letteral>
-      ,
-      <letteral>e</letteral>
-      ,
-      <letteral>i</letteral>
-      ,
-      <letteral>o</letteral>
-      ,
+      <letteral>a</letteral>,
+      <letteral>e</letteral>,
+      <letteral>i</letteral>,
+      <letteral>o</letteral>,
       <letteral>u</letteral>
       and
       <letteral>y</letteral>. The first five are roughly pronounced as
       <quote>a</quote>
       as in
-      <quote>father</quote>
-      ,
+      <quote>father</quote>,
       <letteral>e</letteral>
       as in
-      <quote>let</quote>
-      ,
+      <quote>let</quote>,
       <letteral>i</letteral>
       as in
-      <quote>machine</quote>
-      ,
+      <quote>machine</quote>,
       <letteral>o</letteral>
       as in
       <quote>dome</quote>
@@ -195,8 +187,8 @@
       <quote>flute</quote>.
       <letteral>y</letteral>
       is pronounced as the sound called
-      <quote>schwa</quote>
-      , that is, as the unstressed
+      <quote>schwa</quote>,
+      that is, as the unstressed
       <quote>a</quote>
       as in
       <quote>about</quote>
@@ -208,35 +200,25 @@
         <tertiary>quick-tour version</tertiary>
       </indexterm>
       Twelve consonants in Lojban are pronounced more or less as their counterparts are in English:
-      <letteral>b</letteral>
-      ,
-      <letteral>d</letteral>
-      ,
-      <letteral>f</letteral>
-      ,
-      <letteral>k</letteral>
-      ,
-      <letteral>l</letteral>
-      ,
-      <letteral>m</letteral>
-      ,
-      <letteral>n</letteral>
-      ,
-      <letteral>p</letteral>
-      ,
-      <letteral>r</letteral>
-      ,
-      <letteral>t</letteral>
-      ,
+      <letteral>b</letteral>,
+      <letteral>d</letteral>,
+      <letteral>f</letteral>,
+      <letteral>k</letteral>,
+      <letteral>l</letteral>,
+      <letteral>m</letteral>,
+      <letteral>n</letteral>,
+      <letteral>p</letteral>,
+      <letteral>r</letteral>,
+      <letteral>t</letteral>,
       <letteral>v</letteral>
       and
       <letteral>z</letteral>. The letter
-      <letteral>c</letteral>
-      , on the other hand is pronounced as the
+      <letteral>c</letteral>,
+      on the other hand is pronounced as the
       <quote>sh</quote>
       in
-      <quote>hush</quote>
-      , while
+      <quote>hush</quote>,
+      while
       <letteral>j</letteral>
       is its voiced counterpart, the sound of the
       <quote>s</quote>
@@ -244,28 +226,28 @@
       <quote>pleasure</quote>.
       <letteral>g</letteral>
       is always pronounced as it is in
-      <quote>gift</quote>
-      , never as in
+      <quote>gift</quote>,
+      never as in
       <quote>giant</quote>.
       <letteral>s</letteral>
       is as in
-      <quote>sell</quote>
-      , never as in
+      <quote>sell</quote>,
+      never as in
       <quote>rose</quote>. The sound of
       <letteral>x</letteral>
       is not found in English in normal words. It is found as
       <quote xml:lang="sco">ch</quote>
       in Scottish
-      <quote xml:lang="sco">loch</quote>
-      , as
+      <quote xml:lang="sco">loch</quote>,
+      as
       <quote xml:lang="es">j</quote>
       in Spanish
-      <quote xml:lang="es">junta</quote>
-      , and as
+      <quote xml:lang="es">junta</quote>,
+      and as
       <quote xml:lang="de">ch</quote>
       in German
-      <quote xml:lang="de">Bach</quote>
-      ; it also appears in the English interjection
+      <quote xml:lang="de">Bach</quote>;
+      it also appears in the English interjection
       <quote>yecchh!</quote>. It gets easier to say as you practice it. The letter
       <letteral>r</letteral>
       can be trilled, but doesn't have to be.
@@ -275,20 +257,16 @@
         <tertiary>quick-tour version</tertiary>
       </indexterm>
       The Lojban diphthongs
-      <diphthong>ai</diphthong>
-      ,
-      <diphthong>ei</diphthong>
-      ,
-      <diphthong>oi</diphthong>
-      , and
+      <diphthong>ai</diphthong>,
+      <diphthong>ei</diphthong>,
+      <diphthong>oi</diphthong>,
+      and
       <diphthong>au</diphthong>
       are pronounced much as in the English words
-      <quote>sigh</quote>
-      ,
-      <quote>say</quote>
-      ,
-      <quote>boy</quote>
-      , and
+      <quote>sigh</quote>,
+      <quote>say</quote>,
+      <quote>boy</quote>,
+      and
       <quote>how</quote>. Other Lojban diphthongs begin with an
       <letteral>i</letteral>
       pronounced like English
@@ -313,16 +291,16 @@
       <indexterm type="general"><primary>apostrophe</primary><secondary>quick-tour version</secondary>
       </indexterm>
       Lojban also has three
-      <quote>semi-letters</quote>
-      : the period, the comma and the apostrophe. The period represents a glottal stop or a pause; it is a required stoppage of the flow of air in the speech stream. The apostrophe sounds just like the English letter
+      <quote>semi-letters</quote>;
+      the period, the comma and the apostrophe. The period represents a glottal stop or a pause; it is a required stoppage of the flow of air in the speech stream. The apostrophe sounds just like the English letter
       <quote>h</quote>. Unlike a regular consonant, it is not found at the beginning or end of a word, nor is it found adjacent to a consonant; it is only found between two vowels. The comma has no sound associated with it, and is used to separate syllables that might ordinarily run together. It is not used in this chapter.
     </para>
     <para>
       <indexterm type="general"><primary>stress</primary><secondary>quick-tour version</secondary>
       </indexterm>
       Stress falls on the next to the last syllable of all words, unless that vowel is
-      <letteral>y</letteral>
-      , which is never stressed; in such words the third-to-last syllable is stressed. If a word only has one syllable, then that syllable is not stressed.
+      <letteral>y</letteral>,
+      which is never stressed; in such words the third-to-last syllable is stressed. If a word only has one syllable, then that syllable is not stressed.
     </para>
     <para>All Lojban words are pronounced as they are spelled: there are no silent letters.</para>
   </section>
@@ -367,10 +345,9 @@
       <indexterm type="general"><primary>pointing cmavo</primary><secondary>quick-tour version</secondary>
       </indexterm>
       The cmavo
-      <valsi>ti</valsi>
-      ,
-      <valsi>ta</valsi>
-      , and
+      <valsi>ti</valsi>,
+      <valsi>ta</valsi>,
+      and
       <valsi>tu</valsi>
       refer to whatever the speaker is pointing at, and should not be used to refer to things that cannot in principle be pointed at.
     </para>
@@ -378,8 +355,7 @@
       <indexterm type="general"><primary>names</primary><secondary>quick-tour version</secondary>
       </indexterm>
       Names may also be used as sumti, provided they are preceded with the word
-      <valsi>la</valsi>
-      :
+      <valsi>la</valsi>:
     </para>
     <informaltable>
       <tr>
@@ -503,8 +479,8 @@
     <para>
       <indexterm type="general"><primary>words not in the dictionary</primary></indexterm>
       Like the table in
-      <xref linkend="section-sumti-cmavo" />
-      , this table is far from complete: in fact, no complete table can exist, because Lojban allows new words to be created (in specified ways) whenever a speaker or writer finds the existing supply of words inadequate. This notion is a basic difference between Lojban (and some other languages such as German and Chinese) and English; in English, most people are very leery of using words that
+      <xref linkend="section-sumti-cmavo" />,
+      this table is far from complete: in fact, no complete table can exist, because Lojban allows new words to be created (in specified ways) whenever a speaker or writer finds the existing supply of words inadequate. This notion is a basic difference between Lojban (and some other languages such as German and Chinese) and English; in English, most people are very leery of using words that
       <quote>aren't in the dictionary</quote>. Lojbanists are encouraged to invent new words; doing so is a major way of participating in the development of the language.
       <xref linkend="chapter-morphology" />
       explains how to make new words, and
@@ -641,8 +617,8 @@
       is a so-called letteral for the Lojban letter
       <quote>l</quote>
       and refers to something labelled
-      <quote>l</quote>
-      , most likely the language
+      <quote>l</quote>,
+      most likely the language
       <quote>Lojban</quote>
       as its first letter is
       <quote>l</quote>).
@@ -801,8 +777,8 @@
       <indexterm type="general"><primary>observatives</primary><secondary>quick-tour version</secondary>
       </indexterm>
       If there are no sumti before the selbri, then it is understood that the x<subscript>1</subscript> sumti value is equivalent to
-      <valsi>zo'e</valsi>
-      ; i.e. unimportant or obvious, and therefore not given. Any sumti after the selbri start counting from x<subscript>2</subscript>.
+      <valsi>zo'e</valsi>;
+      i.e. unimportant or obvious, and therefore not given. Any sumti after the selbri start counting from x<subscript>2</subscript>.
     </para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k0br">
       <title><anchor xml:id="c2e6d4" /></title>
@@ -875,7 +851,7 @@
   </section>
   <section xml:id="section-order-of-sumti">
     <title><anchor xml:id="c2s7" />Varying the order of sumti</title>
-    <para>      <indexterm type="general"><primary>sumti reordering</primary><secondary>quick-tour version</secondary>      </indexterm>      For one reason or another you may want to change the order, placing one particular sumti at the front of the bridi. The cmavo      <valsi>se</valsi>      , when placed before the last word of the selbri, will switch the meanings of the first and second sumti places. So
+    <para>      <indexterm type="general"><primary>sumti reordering</primary><secondary>quick-tour version</secondary>      </indexterm>      For one reason or another you may want to change the order, placing one particular sumti at the front of the bridi. The cmavo      <valsi>se</valsi>, when placed before the last word of the selbri, will switch the meanings of the first and second sumti places. So
     </para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k0dU">
       <title><anchor xml:id="c2e7d1" /></title>
@@ -906,8 +882,8 @@
     </example>
     <para role="indent">
       The cmavo
-      <valsi>te</valsi>
-      , when used in the same location, switches the meanings of the first and the third sumti places.
+      <valsi>te</valsi>,
+      when used in the same location, switches the meanings of the first and the third sumti places.
     </para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k0FJ">
       <title><anchor xml:id="c2e7d3" /></title>
@@ -943,14 +919,12 @@
       and
       <valsi>xe</valsi>
       switch the first and fourth sumti places, and the first and fifth sumti places, respectively. These changes in the order of places are known as
-      <quote>conversions</quote>
-      , and the
-      <valsi>se</valsi>
-      ,
-      <valsi>te</valsi>
-      ,
-      <valsi>ve</valsi>
-      , and
+      <quote>conversions</quote>,
+      and the
+      <valsi>se</valsi>,
+      <valsi>te</valsi>,
+      <valsi>ve</valsi>,
+      and
       <valsi>xe</valsi>
       cmavo are said to convert the selbri.
     </para>
@@ -990,10 +964,10 @@
       The cmavo
       <valsi>.i</valsi>
       separates sentences. It is sometimes compounded with words that modify the exact meaning (the semantics) of the sentence in the context of the utterance. (The cmavo
-      <valsi>xu</valsi>
-      , discussed in
-      <xref linkend="section-basic-questions" />
-      , is one such word &ndash; it turns the sentence from a statement to a question about truth.) When more than one person is talking, a new speaker will usually omit the
+      <valsi>xu</valsi>,
+      discussed in
+      <xref linkend="section-basic-questions" />,
+      is one such word &ndash; it turns the sentence from a statement to a question about truth.) When more than one person is talking, a new speaker will usually omit the
       <valsi>.i</valsi>
       even though she/he may be continuing on the same topic.
     </para>
@@ -1114,8 +1088,7 @@
         <tertiary>quick-tour version</tertiary>
       </indexterm>
       The place structure of a tanru is always that of the final component of the tanru. Thus, the following has the place structure of
-      <valsi>klama</valsi>
-      :
+      <valsi>klama</valsi>:
     </para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k0FP">
       <title><anchor xml:id="c2e9d8" /></title>
@@ -1142,8 +1115,8 @@
       With the conversion
       <jbophrase>se klama</jbophrase>
       as the final component of the tanru, the place structure of the entire selbri is that of
-      <jbophrase>se klama</jbophrase>
-      : the x<subscript>1</subscript> place is the destination, and the x<subscript>2</subscript> place is the one who goes:
+      <jbophrase>se klama</jbophrase>:
+      the x<subscript>1</subscript> place is the destination, and the x<subscript>2</subscript> place is the one who goes:
     </para>
 
     <example role="interlinear-gloss-example" xml:id="example-random-id-k0J1">
@@ -1198,8 +1171,8 @@
     </example>
     <para role="noindent">
       has the place structure of
-      <valsi>tavla</valsi>
-      , but note the two distinct interpretations.
+      <valsi>tavla</valsi>,
+      but note the two distinct interpretations.
     </para>
     <para>Now, using conversion, we can modify the place structure order:</para>
 
@@ -1275,8 +1248,8 @@
       <quote>description sumti</quote>. The description sumti
       <jbophrase>le tavla ku</jbophrase>
       means
-      <quote>the talker</quote>
-      , and may be used wherever any sumti may be used.
+      <quote>the talker</quote>,
+      and may be used wherever any sumti may be used.
     </para>
     <para>For example,</para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k0Pj">
@@ -1307,8 +1280,8 @@
       Similarly
       <jbophrase>le sutra tavla ku</jbophrase>
       is
-      <quote>the fast talker</quote>
-      , and
+      <quote>the fast talker</quote>,
+      and
       <jbophrase>le sutra te tavla ku</jbophrase>
       is
       <quote>the fast subject of talk</quote>
@@ -1353,10 +1326,10 @@
       translation
       <jbophrase>le sutra tavla</jbophrase>
       turns out to mean
-      <quote>the fast talker</quote>
-      , and has no selbri at all. To solve this problem we can use the word
-      <valsi>cu</valsi>
-      , which so far has always been optional, in front of the selbri.
+      <quote>the fast talker</quote>,
+      and has no selbri at all. To solve this problem we can use the word
+      <valsi>cu</valsi>,
+      which so far has always been optional, in front of the selbri.
     </para>
     <para>
       The word
@@ -1457,23 +1430,23 @@
       The sumti
       <jbophrase>le vecnu</jbophrase>
       contains the selbri
-      <valsi>vecnu</valsi>
-      , which has the
+      <valsi>vecnu</valsi>,
+      which has the
       <quote>seller</quote>
       in the x<subscript>1</subscript> place, and uses it in this sentence to describe a particular
       <quote>seller</quote>
       that the speaker has in mind (one that he or she probably expects the listener will also know about). Similarly, the speaker has a particular blue-green thing in mind, which is described using
       <valsi>le</valsi>
       to mark
-      <valsi>blari'o</valsi>
-      , a selbri whose first sumti is something blue-green.
+      <valsi>blari'o</valsi>,
+      a selbri whose first sumti is something blue-green.
     </para>
     <para>
       It is safe to omit both occurrences of
       <valsi>ku</valsi>
       in
-      <xref linkend="example-random-id-k0S1" />
-      , and it is also safe to omit the
+      <xref linkend="example-random-id-k0S1" />,
+      and it is also safe to omit the
       <valsi>cu</valsi>.
     </para>
   </section>
@@ -1559,8 +1532,8 @@
       <indexterm type="general"><primary>cmavo as selbri</primary><secondary>quick-tour version</secondary>
       </indexterm>
       Some cmavo may also serve as selbri, acting as variables that stand for another selbri. The most commonly used of these is
-      <valsi>go'i</valsi>
-      , which represents the main bridi of the previous Lojban sentence, with any new sumti or other sentence features being expressed replacing the previously expressed ones. Thus, in this context:
+      <valsi>go'i</valsi>,
+      which represents the main bridi of the previous Lojban sentence, with any new sumti or other sentence features being expressed replacing the previously expressed ones. Thus, in this context:
     </para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k0UC">
       <title><anchor xml:id="c2e11d4" /></title>
@@ -1583,7 +1556,7 @@
   </section>
   <section xml:id="section-dihu-and-lahe-dihu">
     <title><anchor xml:id="c2s12" />The sumti <valsi>di'u</valsi> and <jbophrase>la'e di'u</jbophrase></title>
-    <para>      <indexterm type="general"><primary>reference</primary><secondary>quick-tour version</secondary>      </indexterm>      In English, I might say      <quote>The dog is beautiful</quote>      , and you might reply
+    <para>      <indexterm type="general"><primary>reference</primary><secondary>quick-tour version</secondary>      </indexterm>      In English, I might say      <quote>The dog is beautiful</quote>, and you might reply
       <quote>This pleases me.</quote>
       How do you know what
       <quote>this</quote>
@@ -1710,8 +1683,7 @@
     <para role="noindent">
       means
       <quote>Oh, John, I'm talking to you</quote>. It also has the effect of setting the value of
-      <valsi>do</valsi>
-      ;
+      <valsi>do</valsi>;
       <valsi>do</valsi>
       now refers to
       <quote>John</quote>
@@ -1861,8 +1833,8 @@
       both mean
       <quote>You take care of you</quote>
       and
-      <quote>Be taken care of by you</quote>
-      , or to put it colloquially,
+      <quote>Be taken care of by you</quote>,
+      or to put it colloquially,
       <quote>Take care of yourself</quote>.
     </para>
   </section>
@@ -1886,10 +1858,9 @@
       or
       <quote>What?</quote>
       in most cases, but also serves for
-      <quote>When?</quote>
-      ,
-      <quote>Where?</quote>
-      , and
+      <quote>When?</quote>,
+      <quote>Where?</quote>,
+      and
       <quote>Why?</quote>
       when used in sumti places that express time, location, or cause. For example:
     </para>
@@ -1925,8 +1896,7 @@
     </example>
     <para role="indent">
       Like
-      <valsi>ko</valsi>
-      ,
+      <valsi>ko</valsi>,
       <valsi>ma</valsi>
       can occur in any position where a sumti is allowed, not just in the first position:
     </para>
@@ -1988,8 +1958,7 @@
       <valsi>mo</valsi>
       is the selbri analogue of
       <valsi>ma</valsi>. It asks the respondent to provide a selbri that would be a true relation if inserted in place of the
-      <valsi>mo</valsi>
-      :
+      <valsi>mo</valsi>:
     </para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k1DE">
       <title><anchor xml:id="c2e15d5" /></title>
@@ -2061,8 +2030,8 @@
       Finally, we must consider questions that can be answered
       <quote>Yes</quote>
       or
-      <quote>No</quote>
-      , such as
+      <quote>No</quote>,
+      such as
     </para>
     <example xml:id="example-random-id-fVMN">
       <title><anchor xml:id="c2e15d8" /></title>
@@ -2081,8 +2050,8 @@
     </example>
     <para role="indent">
       In Lojban we have a word that asks precisely that question in precisely the same way. The cmavo
-      <valsi>xu</valsi>
-      , when placed in front of a bridi, asks whether that bridi is true as stated. So
+      <valsi>xu</valsi>,
+      when placed in front of a bridi, asks whether that bridi is true as stated. So
     </para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k1gp">
       <title><anchor xml:id="c2e15d10" /></title>
@@ -2118,8 +2087,8 @@
       may be given by simply restating the bridi without the
       <valsi>xu</valsi>
       question word. Lojban has a shorthand for doing this with the word
-      <valsi>go'i</valsi>
-      , mentioned in
+      <valsi>go'i</valsi>,
+      mentioned in
       <xref linkend="section-some-brivla" />. Instead of a negative answer, the bridi may be restated in such a way as to make it true. If this can be done by substituting sumti, it may be done with
       <valsi>go'i</valsi>
       as well. For example:
@@ -2233,14 +2202,11 @@
     <para>      <indexterm type="general"><primary>interjections</primary><secondary>quick-tour version</secondary>      </indexterm>      <indexterm type="general"><primary>attitudinal indicators</primary><secondary>quick-tour version</secondary>      </indexterm>      <indexterm type="general"><primary>indicators</primary><secondary>quick-tour version</secondary>
       </indexterm>
       Different cultures express emotions and attitudes with a variety of intonations and gestures that are not usually included in written language. Some of these are available in some languages as interjections (i.e.
-      <quote>Aha!</quote>
-      ,
-      <quote>Oh no!</quote>
-      ,
-      <quote>Ouch!</quote>
-      ,
-      <quote>Aahh!</quote>
-      , etc.), but they vary greatly from culture to culture.
+      <quote>Aha!</quote>,
+      <quote>Oh no!</quote>,
+      <quote>Ouch!</quote>,
+      <quote>Aahh!</quote>,
+      etc.), but they vary greatly from culture to culture.
     </para>
 
     <para>
@@ -2330,10 +2296,10 @@
       features from the underlying statements and logical structure. By comparison, the English words
       <quote>but</quote>
       and
-      <quote>also</quote>
-      , which discursively indicate contrast or an added weight of example, are logically equivalent to
-      <quote>and</quote>
-      , which does not have a discursive content. The average English-speaker does not think about, and may not even realize, the paradoxical idea that
+      <quote>also</quote>,
+      which discursively indicate contrast or an added weight of example, are logically equivalent to
+      <quote>and</quote>,
+      which does not have a discursive content. The average English-speaker does not think about, and may not even realize, the paradoxical idea that
       <quote>but</quote>
       basically means
       <quote>and</quote>.
@@ -2518,8 +2484,8 @@
       serves as a translation of either
       <xref linkend="example-random-id-xIVa" />
       or
-      <xref linkend="example-random-id-1Acu" />
-      , and of many other possible English sentences as well. It is not marked for tense, and can refer to an event in the past, the present or the future. This rule does not mean that Lojban has no way of representing the time of an event. A close translation of
+      <xref linkend="example-random-id-1Acu" />,
+      and of many other possible English sentences as well. It is not marked for tense, and can refer to an event in the past, the present or the future. This rule does not mean that Lojban has no way of representing the time of an event. A close translation of
       <xref linkend="example-random-id-xIVa" />
       would be:
     </para>
@@ -2567,8 +2533,8 @@
     <para role="noindent">
       necessarily refers to the present, because of the tag
       <valsi>ca</valsi>. Tags used in this way always appear at the very beginning of the selbri, just after the
-      <valsi>cu</valsi>
-      , and they may make a
+      <valsi>cu</valsi>,
+      and they may make a
       <valsi>cu</valsi>
       unnecessary, since tags cannot be absorbed into tanru. Such tags serve as an equivalent to English tenses and adverbs. In Lojban, tense information is completely optional. If unspecified, the appropriate tense is picked up from context.
     </para>
@@ -2626,8 +2592,7 @@
       as adjectives, as in the following example, which uses the tag
       <valsi>vi</valsi>
       meaning
-      <quote>nearby</quote>
-      :
+      <quote>nearby</quote>:
     </para>
     <example role="interlinear-gloss-example" xml:id="example-random-id-k28N">
       <title><anchor xml:id="c2e17d8" /></title>
@@ -2654,10 +2619,10 @@
       in
       <xref linkend="example-random-id-k28N" />
       with the cmavo
-      <valsi>ti</valsi>
-      , which also means
-      <quote>this</quote>
-      , but in the sense of
+      <valsi>ti</valsi>,
+      which also means
+      <quote>this</quote>,
+      but in the sense of
       <quote>this thing</quote>.
     </para>
     <para>
@@ -2672,19 +2637,18 @@
 
       <interlinear-gloss-itemized>
         <jbo>
-          <sumti>le vi tavla </sumti>
+          <sumti>le ca vi tavla </sumti>
           <elidable>ku</elidable>
-          <elidable elidable="false">cu</elidable>
-          <selbri>ba klama</selbri>
+          <elidable>cu</elidable>
+          <selbri>ba vu tavla</selbri>
         </jbo>
         <gloss>
-          <sumti>The here talker</sumti>
+          <sumti>The [present] here talker</sumti>
           <elidable></elidable>
           <elidable></elidable>
-          <selbri>[future] goes.</selbri>
+          <selbri>[future] there talks.</selbri>
         </gloss>
-        <natlang>The talker who is here will go.</natlang>
-        <natlang>This talker will go.</natlang>
+        <natlang>The one who is talking here will talk there.</natlang>
       </interlinear-gloss-itemized>
     </example>
   </section>


### PR DESCRIPTION
Also includes cleanup of extra spacing around punctuation that was added during an auto-format.